### PR TITLE
Dashboard architecture: client-side tab routing + reusable UI components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
-import Header from "@/components/common/Header";
+"use client";
+
+import { useState } from "react";
 import Sidebar from "@/components/common/Sidebar";
+import PageRouter from "@/components/common/PageRouter";
+import { TabType } from "@/components/common/PageRouter";
 
 export default function Dashboard() {
+  const [activeTab, setActiveTab] = useState<TabType>("dashboard");
+
   return (
     <div className="min-h-screen bg-white">
       {/* Top Bar */}
@@ -9,22 +15,10 @@ export default function Dashboard() {
       
       <div className="flex">
         {/* Left Sidebar */}
-        <Sidebar />
+        <Sidebar activeTab={activeTab} setActiveTab={setActiveTab} />
 
         {/* Main Content */}
-        <main className="flex-1 p-8">
-          
-
-          {/* Dashboard Header */}
-          <Header 
-            title="Dashboard"
-            subtitle="Monitor real-time security analysis and threat detection"
-          />  
-
-            
-
-                
-        </main>
+        <PageRouter activeTab={activeTab} />
       </div>
     </div>
   );

--- a/src/components/common/PageRouter.tsx
+++ b/src/components/common/PageRouter.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import DashboardPage from "@/components/pages/DashboardPage";
+
+type TabType = "dashboard" | "audits" | "past-audits" | "projects";
+
+interface PageRouterProps {
+  activeTab: TabType;
+}
+
+export default function PageRouter({ activeTab }: PageRouterProps) {
+  const renderPage = () => {
+    switch (activeTab) {
+      case "dashboard":
+        return <DashboardPage />;
+      case "audits":
+        return <div className="flex-1 p-8">Audits Page - Coming Soon</div>;
+      case "past-audits":
+        return <div className="flex-1 p-8">Past Audits Page - Coming Soon</div>;
+      case "projects":
+        return <div className="flex-1 p-8">Projects Page - Coming Soon</div>;
+      default:
+        return <DashboardPage />;
+    }
+  };
+
+  return (
+    <>
+      {renderPage()}
+    </>
+  );
+}
+
+// Export the setActiveTab function so it can be used by the Sidebar
+export { type TabType };

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -4,8 +4,14 @@ import {
   Clock, 
   Folder, 
 } from "lucide-react";
+import { TabType } from "./PageRouter";
 
-export default function Sidebar() {
+interface SidebarProps {
+  activeTab: TabType;
+  setActiveTab: (tab: TabType) => void;
+}
+
+export default function Sidebar({ activeTab, setActiveTab }: SidebarProps) {
   return (
     <aside className="w-64 bg-gray-50 shadow-sm min-h-screen">
       <div className="p-6">
@@ -13,35 +19,54 @@ export default function Sidebar() {
         <div className="h-24 mb-8"></div>
         
         <nav className="space-y-4">
-          <a 
-            href="#" 
-            className="flex items-center gap-3 px-3 py-4 text-black-700 rounded-lg font-bold border border-black"
-            style={{ backgroundColor: '#AFFDC3' }}
+          <button 
+            onClick={() => setActiveTab("dashboard")}
+            className={`flex items-center gap-3 px-3 py-4 rounded-lg font-bold w-full text-left ${
+              activeTab === "dashboard" 
+                ? "text-black-700 border border-black" 
+                : "text-gray-700 hover:bg-gray-100"
+            }`}
+            style={activeTab === "dashboard" ? { backgroundColor: '#AFFDC3' } : {}}
           >
             <LayoutDashboard className="w-5 h-5" />
             Dashboard
-          </a>
-          <a 
-            href="#" 
-            className="flex items-center gap-3 px-3 py-3 text-black-700 hover:bg-gray-50 rounded-lg font-bold"
+          </button>
+          <button 
+            onClick={() => setActiveTab("audits")}
+            className={`flex items-center gap-3 px-3 py-3 rounded-lg font-bold w-full text-left ${
+              activeTab === "audits" 
+                ? "text-black-700 border border-black" 
+                : "text-gray-700 hover:bg-gray-100"
+            }`}
+            style={activeTab === "audits" ? { backgroundColor: '#AFFDC3' } : {}}
           >
             <FileText className="w-5 h-5" />
             Audits
-          </a>
-          <a 
-            href="#" 
-            className="flex items-center gap-3 px-3 py-3 text-black-700 hover:bg-gray-50 rounded-lg font-bold"
+          </button>
+          <button 
+            onClick={() => setActiveTab("past-audits")}
+            className={`flex items-center gap-3 px-3 py-3 rounded-lg font-bold w-full text-left ${
+              activeTab === "past-audits" 
+                ? "text-black-700 border border-black" 
+                : "text-gray-700 hover:bg-gray-100"
+            }`}
+            style={activeTab === "past-audits" ? { backgroundColor: '#AFFDC3' } : {}}
           >
             <Clock className="w-5 h-5" />
             Past Audits
-          </a>
-          <a 
-            href="#" 
-            className="flex items-center gap-3 px-3 py-3 text-black-700 hover:bg-gray-50 rounded-lg font-bold"
+          </button>
+          <button 
+            onClick={() => setActiveTab("projects")}
+            className={`flex items-center gap-3 px-3 py-3 rounded-lg font-bold w-full text-left ${
+              activeTab === "projects" 
+                ? "text-black-700 border border-black" 
+                : "text-gray-700 hover:bg-gray-100"
+            }`}
+            style={activeTab === "projects" ? { backgroundColor: '#AFFDC3' } : {}}
           >
             <Folder className="w-5 h-5" />
             Projects
-          </a>
+          </button>
         </nav>
       </div>
     </aside>

--- a/src/components/pages/DashboardPage.tsx
+++ b/src/components/pages/DashboardPage.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Header from "@/components/common/Header";
+
+export default function DashboardPage() {
+  return (
+    <main className="flex-1 p-8">
+      {/* Dashboard Header */}
+      <Header 
+        title="Dashboard"
+        subtitle="Monitor real-time security analysis and threat detection"
+      />
+      
+    </main>
+  );
+}


### PR DESCRIPTION



### Description
- Add `Sidebar` with active tab state and highlight; clicks update body only.
- Introduce `PageRouter(activeTab)` to swap page content without reload.
- Create `DashboardPage` container for dashboard body.
- Update `app/page.tsx` to manage `activeTab` and pass to `Sidebar`/`PageRouter`.
- Cleanups: remove unused `useState` in router, minor style tweaks.