### PR TITLE
feat: Refactor KPIGrid and add to Past Audit page

### DIFF
--- a/src/components/common/KPIGrid.tsx
+++ b/src/components/common/KPIGrid.tsx
@@ -1,33 +1,30 @@
-import { BarChart3, Hourglass, CheckCircle, Shield } from "lucide-react";
+import { BarChart3, Hourglass, CheckCircle, ShieldAlert ,CircleX} from "lucide-react";
 import StatsCard from "@/components/ui/StatsCard";
 
-export default function KPIGrid() {
-  const stats = [
-    {
-      icon: BarChart3,
-      label: "Projects",
-      value: "4",
-      iconColor: "text-black-600"
-    },
-    {
-      icon: Hourglass,
-      label: "Running Audits",
-      value: "1",
-      iconColor: "text-black-600"
-    },
-    {
-      icon: CheckCircle,
-      label: "Completed",
-      value: "2",
-      iconColor: "text-black-600"
-    },
-    {
-      icon: Shield,
-      label: "Total Findings",
-      value: "8",
-      iconColor: "text-black-600"
-    }
-  ];
+interface KPIData {
+  icon: string;
+  label: string;
+  value: string;
+  iconColor: string;
+}
+
+interface KPIGridProps {
+  kpiData: KPIData[];
+}
+
+export default function KPIGrid({ kpiData }: KPIGridProps) {
+  const iconMap = {
+    BarChart3,
+    Hourglass,
+    CheckCircle,
+    ShieldAlert,
+    CircleX
+  };
+
+  const stats = kpiData.map(item => ({
+    ...item,
+    icon: iconMap[item.icon as keyof typeof iconMap]
+  }));
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">

--- a/src/components/pages/DashboardPage.tsx
+++ b/src/components/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/common/Header";
 import KPIGrid from "@/components/common/KPIGrid";
 import UploadCard from "@/components/common/UploadCard";
 import RecentActivity from "@/components/common/RecentActivity";
+import dashboardKpiData from "@/data/dashboardKPI.json";
 
 export default function DashboardPage() {
   return (
@@ -14,7 +15,7 @@ export default function DashboardPage() {
         subtitle="Monitor real-time security analysis and threat detection"
       />
 
-      <KPIGrid />
+      <KPIGrid kpiData={dashboardKpiData} />
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <UploadCard />

--- a/src/components/pages/PastAuditsPage.tsx
+++ b/src/components/pages/PastAuditsPage.tsx
@@ -1,4 +1,6 @@
 import Header from "@/components/common/Header";
+import KPIGrid from "../common/KPIGrid";
+import pastAuditData from "@/data/pastAuditKPI.json";
 
 
 export default function PastAuditPage(){
@@ -8,6 +10,7 @@ export default function PastAuditPage(){
                 title="Audit History"
                 subtitle="Review completed security analysis and findings"
             />
+            <KPIGrid kpiData={pastAuditData} />
         </main>
     );
 }

--- a/src/data/dashboardKPI.json
+++ b/src/data/dashboardKPI.json
@@ -1,0 +1,26 @@
+[
+  {
+    "icon": "BarChart3",
+    "label": "Projects",
+    "value": "4",
+    "iconColor": "text-black-600"
+  },
+  {
+    "icon": "Hourglass",
+    "label": "Running Audits",
+    "value": "1",
+    "iconColor": "text-black-600"
+  },
+  {
+    "icon": "CheckCircle",
+    "label": "Completed",
+    "value": "2",
+    "iconColor": "text-black-600"
+  },
+  {
+    "icon": "ShieldAlert",
+    "label": "Total Findings",
+    "value": "8",
+    "iconColor": "text-black-600"
+  }
+]

--- a/src/data/pastAuditKPI.json
+++ b/src/data/pastAuditKPI.json
@@ -1,0 +1,26 @@
+[
+  {
+    "icon": "BarChart3",
+    "label": "Total Audits",
+    "value": "3",
+    "iconColor": "text-black-600"
+  },
+  {
+    "icon": "CheckCircle",
+    "label": "Completed",
+    "value": "1",
+    "iconColor": "text-black-600"
+  },
+  {
+    "icon": "CircleX",
+    "label": "Failed",
+    "value": "2",
+    "iconColor": "text-black-600"
+  },
+  {
+    "icon": "ShieldAlert",
+    "label": "Total Findings",
+    "value": "8",
+    "iconColor": "text-black-600"
+  }
+]


### PR DESCRIPTION
## Changes
- Refactored `KPIGrid` component to accept `kpiData` as a prop instead of hardcoded stats
- Added TypeScript interfaces for type safety (`KPIData`, `KPIGridProps`)
- Created separate JSON data files:
  - `dashboardKPI.json` - Dashboard page metrics
  - `pastAuditKPI.json` - Past audits page metrics
- Updated `DashboardPage` and `PastAuditsPage` to use the refactored component
- Enhanced icon mapping to support `ShieldAlert` and `CircleX` icons

## Benefits
- Improved component reusability across different pages
- Better separation of data and presentation logic
- Type-safe props with TypeScript interfaces
- Easier maintenance of KPI data without touching component code