### PR TITLE
feat: Add past audits data and integrate AuditTable in PastAuditPage

### DIFF
--- a/src/components/pages/PastAuditsPage.tsx
+++ b/src/components/pages/PastAuditsPage.tsx
@@ -1,6 +1,8 @@
 import Header from "@/components/common/Header";
 import KPIGrid from "../common/KPIGrid";
+import AuditTable from "../common/AuditTable";
 import pastAuditData from "@/data/pastAuditKPI.json";
+import pastAuditsData from "@/data/pastAudits.json";
 
 
 export default function PastAuditPage(){
@@ -11,6 +13,7 @@ export default function PastAuditPage(){
                 subtitle="Review completed security analysis and findings"
             />
             <KPIGrid kpiData={pastAuditData} />
+            <AuditTable audits={pastAuditsData} />
         </main>
     );
 }

--- a/src/data/pastAudits.json
+++ b/src/data/pastAudits.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "project": "ABC BANK",
+    "size": "4.3MB",
+    "status": "completed",
+    "severity": "Medium",
+    "findings": 3,
+    "duration": "30:05",
+    "completed": "1st August 2025"
+  },
+  {
+    "id": 2,
+    "project": "ABC BANK",
+    "size": "4.3MB", 
+    "status": "completed",
+    "severity": "Medium",
+    "findings": 3,
+    "duration": "30:05",
+    "completed": "1st August 2025"
+  },
+  {
+    "id": 3,
+    "project": "ABC BANK",
+    "size": "4.3MB",
+    "status": "failed",
+    "severity": "n/a",
+    "findings": 0,
+    "duration": "n/a",
+    "completed": "n/a"
+  }
+]


### PR DESCRIPTION
## Changes
- Created `pastAudits.json` with dummy audit data (2 completed, 1 failed)
- Integrated `AuditTable` component into `PastAuditsPage`
- Added proper imports for audit data and table component

## Features
- Past audits page now displays audit history table below KPI metrics
- Table shows project details, status, severity, findings, and completion data
- Status-based icons and action buttons for each audit entry
- Responsive design matching the application's styling

## Data Structure
- Audit records include: project name, file size, status, severity, findings count, duration, and completion date
- Failed audits show "n/a" for relevant fields (severity, duration, completion)
<img width="1425" height="274" alt="image" src="https://github.com/user-attachments/assets/cec8a006-9ffc-46d0-b766-ba7aa3199f47" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Past Audits overview with KPI cards (Total Audits, Completed, Failed, Total Findings).
  * Introduced a scrollable Past Audits table showing project, size, status with icons, severity, findings, duration, completion date, and quick actions (View, Download, Retry).
  * Dashboard KPI cards now populated from data to reflect current stats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->