### PR TITLE
feat: Enhance search functionality in ActiveAuditClient and AuditsClient with status filtering

### DIFF
--- a/src/components/audits/ActiveAuditClient.tsx
+++ b/src/components/audits/ActiveAuditClient.tsx
@@ -2,19 +2,23 @@
 
 import React, { useState, createContext, useContext } from "react";
 import SearchAndFilter from "@/components/ui/SearchAndFilter";
-import  AuditsClient from "@/components/audits/AuditsClient";
+import { AuditsClient } from "@/components/audits/AuditsClient";
 import { type AuditCard } from "@/actions/activities";
+import { CirclePauseIcon , CirclePlayIcon } from "lucide-react";
 
 // Context for search state
 const SearchContext = createContext<{
   searchTerm: string;
   setSearchTerm: (term: string) => void;
+  selectedFilters: string[];
+  setSelectedFilters: (filters: string[]) => void;
 } | undefined>(undefined);
 
 export function SearchProvider({ children }: { children: React.ReactNode }) {
   const [searchTerm, setSearchTerm] = useState("");
+  const [selectedFilters, setSelectedFilters] = useState<string[]>(["active", "queued"]);
   return (
-    <SearchContext.Provider value={{ searchTerm, setSearchTerm }}>
+    <SearchContext.Provider value={{ searchTerm, setSearchTerm, selectedFilters, setSelectedFilters }}>
       {children}
     </SearchContext.Provider>
   );
@@ -23,12 +27,26 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
 export function SearchInput() {
   const ctx = useContext(SearchContext);
   if (!ctx) return null;
+  const filterOptions = [
+    {
+      value: "active",
+      label: "",
+      icon: <CirclePlayIcon className="w-4 h-4 text-primary" />
+    },
+    {
+      value: "queued",
+      label: "",
+      icon: <CirclePauseIcon className="w-4 h-4 text-destructive" />
+    }
+  ];
   return (
     <SearchAndFilter
       searchPlaceholder="Search audits..."
       onSearch={ctx.setSearchTerm}
       showFilter={true}
-      filterOptions={[]}
+      filterOptions={filterOptions}
+      selectedFilters={ctx.selectedFilters}
+      onFilterChange={ctx.setSelectedFilters}
     />
   );
 }
@@ -36,5 +54,6 @@ export function SearchInput() {
 export function SearchableActiveAuditList({ initialAudits }: { initialAudits: AuditCard[] }) {
   const ctx = useContext(SearchContext);
   const searchTerm = ctx?.searchTerm || "";
-  return <AuditsClient initialAudits={initialAudits} searchQuery={searchTerm} />;
+  const selectedFilters = ctx?.selectedFilters || ["active", "queued"];
+  return <AuditsClient initialAudits={initialAudits} searchQuery={searchTerm} statusFilter={selectedFilters} />;
 }

--- a/src/components/audits/ActiveAuditClient.tsx
+++ b/src/components/audits/ActiveAuditClient.tsx
@@ -4,7 +4,7 @@ import React, { useState, createContext, useContext } from "react";
 import SearchAndFilter from "@/components/ui/SearchAndFilter";
 import { AuditsClient } from "@/components/audits/AuditsClient";
 import { type AuditCard } from "@/actions/activities";
-import { CirclePauseIcon , CirclePlayIcon } from "lucide-react";
+import { CirclePause , CirclePlay } from "lucide-react";
 
 // Context for search state
 const SearchContext = createContext<{
@@ -16,7 +16,7 @@ const SearchContext = createContext<{
 
 export function SearchProvider({ children }: { children: React.ReactNode }) {
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedFilters, setSelectedFilters] = useState<string[]>(["active", "queued"]);
+  const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   return (
     <SearchContext.Provider value={{ searchTerm, setSearchTerm, selectedFilters, setSelectedFilters }}>
       {children}
@@ -31,12 +31,12 @@ export function SearchInput() {
     {
       value: "active",
       label: "",
-      icon: <CirclePlayIcon className="w-4 h-4 text-primary" />
+      icon: <CirclePlay className="w-4 h-4 text-primary" />
     },
     {
       value: "queued",
       label: "",
-      icon: <CirclePauseIcon className="w-4 h-4 text-destructive" />
+      icon: <CirclePause className="w-4 h-4 text-destructive" />
     }
   ];
   return (

--- a/src/components/audits/AuditsClient.tsx
+++ b/src/components/audits/AuditsClient.tsx
@@ -5,21 +5,22 @@ import { useState } from "react";
 import { AuditStatusCard, ActiveAuditCount } from "@/components/audits";
 import { type AuditCard } from "@/actions/activities";
 
-
 interface AuditsClientProps {
   initialAudits: AuditCard[];
   searchQuery?: string;
+  statusFilter?: string[];
 }
 
-
-export default function AuditsClient({ initialAudits, searchQuery = "" }: AuditsClientProps) {
+export function AuditsClient({ initialAudits, searchQuery = "", statusFilter = ["active", "queued"] }: AuditsClientProps) {
   const [auditCards, setAuditCards] = useState<AuditCard[]>(initialAudits);
 
-  // Filter audits by search query before rendering
+  // Filter audits by search query and status before rendering
   const normalizedSearch = searchQuery.toLowerCase();
-  const filteredAudits = normalizedSearch
-    ? auditCards.filter(card => card.title.toLowerCase().includes(normalizedSearch))
-    : auditCards;
+  const filteredAudits = auditCards.filter(card => {
+    const matchesSearch = normalizedSearch ? card.title.toLowerCase().includes(normalizedSearch) : true;
+    const matchesStatus = statusFilter.length > 0 ? statusFilter.includes(card.statusType) : true;
+    return matchesSearch && matchesStatus;
+  });
 
   const handleStatusChange = (id: string, newStatus: "active" | "queued") => {
     setAuditCards(prev => prev.map(card => 


### PR DESCRIPTION



**Description:**  
This PR introduces status filtering to the active audits page:

- Adds `selectedFilters` state and context to `SearchProvider` in `ActiveAuditClient.tsx`.
- Implements a filter dropdown in the search bar with two options: "active" (using `CirclePlayIcon`) and "queued" (using `CirclePauseIcon`).
- Passes selected status filters to `AuditsClient` and applies combined search and status filtering logic.
- Refactors `AuditsClient` to accept a `statusFilter` prop and filter audits by both search term and status.
- Updates exports to use named export for `AuditsClient` in `index.ts`.

These changes allow users to filter audits by status ("active" or "queued") in addition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added search and status filtering to the Audits page with a header search input ("Search audits...").
  - Quick-toggle filters for Active and Queued (icons) and real-time filtering as you type.
  - Search state is shared between the header input and the audits list for a consistent experience.

- UI Improvements
  - Defaults show Active and Queued audits; clearing filters reveals all.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->