### PR TITLE
feat: Implement search functionality in ProjectsPage with SearchProvider and SearchInput components

### DIFF
--- a/src/components/audits/ActiveAuditClient.tsx
+++ b/src/components/audits/ActiveAuditClient.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { useState, createContext, useContext } from "react";
+import SearchAndFilter from "@/components/ui/SearchAndFilter";
+import  AuditsClient from "@/components/audits/AuditsClient";
+import { type AuditCard } from "@/actions/activities";
+
+// Context for search state
+const SearchContext = createContext<{
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+} | undefined>(undefined);
+
+export function SearchProvider({ children }: { children: React.ReactNode }) {
+  const [searchTerm, setSearchTerm] = useState("");
+  return (
+    <SearchContext.Provider value={{ searchTerm, setSearchTerm }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+export function SearchInput() {
+  const ctx = useContext(SearchContext);
+  if (!ctx) return null;
+  return (
+    <SearchAndFilter
+      searchPlaceholder="Search audits..."
+      onSearch={ctx.setSearchTerm}
+      showFilter={true}
+      filterOptions={[]}
+    />
+  );
+}
+
+export function SearchableActiveAuditList({ initialAudits }: { initialAudits: AuditCard[] }) {
+  const ctx = useContext(SearchContext);
+  const searchTerm = ctx?.searchTerm || "";
+  return <AuditsClient initialAudits={initialAudits} searchQuery={searchTerm} />;
+}

--- a/src/components/audits/ActiveAuditClient.tsx
+++ b/src/components/audits/ActiveAuditClient.tsx
@@ -2,19 +2,23 @@
 
 import React, { useState, createContext, useContext } from "react";
 import SearchAndFilter from "@/components/ui/SearchAndFilter";
-import  AuditsClient from "@/components/audits/AuditsClient";
+import { AuditsClient } from "@/components/audits/AuditsClient";
 import { type AuditCard } from "@/actions/activities";
+import { CirclePauseIcon , CirclePlayIcon } from "lucide-react";
 
 // Context for search state
 const SearchContext = createContext<{
   searchTerm: string;
   setSearchTerm: (term: string) => void;
+  selectedFilters: string[];
+  setSelectedFilters: (filters: string[]) => void;
 } | undefined>(undefined);
 
 export function SearchProvider({ children }: { children: React.ReactNode }) {
   const [searchTerm, setSearchTerm] = useState("");
+  const [selectedFilters, setSelectedFilters] = useState<string[]>(["active", "queued"]);
   return (
-    <SearchContext.Provider value={{ searchTerm, setSearchTerm }}>
+    <SearchContext.Provider value={{ searchTerm, setSearchTerm, selectedFilters, setSelectedFilters }}>
       {children}
     </SearchContext.Provider>
   );
@@ -23,12 +27,26 @@ export function SearchProvider({ children }: { children: React.ReactNode }) {
 export function SearchInput() {
   const ctx = useContext(SearchContext);
   if (!ctx) return null;
+  const filterOptions = [
+    {
+      value: "active",
+      label: "",
+      icon: <CirclePlayIcon className="w-4 h-4 text-primary" />
+    },
+    {
+      value: "queued",
+      label: "",
+      icon: <CirclePauseIcon className="w-4 h-4 text-destructive" />
+    }
+  ];
   return (
     <SearchAndFilter
       searchPlaceholder="Search audits..."
       onSearch={ctx.setSearchTerm}
       showFilter={true}
-      filterOptions={[]}
+      filterOptions={filterOptions}
+      selectedFilters={ctx.selectedFilters}
+      onFilterChange={ctx.setSelectedFilters}
     />
   );
 }
@@ -36,5 +54,6 @@ export function SearchInput() {
 export function SearchableActiveAuditList({ initialAudits }: { initialAudits: AuditCard[] }) {
   const ctx = useContext(SearchContext);
   const searchTerm = ctx?.searchTerm || "";
-  return <AuditsClient initialAudits={initialAudits} searchQuery={searchTerm} />;
+  const selectedFilters = ctx?.selectedFilters || ["active", "queued"];
+  return <AuditsClient initialAudits={initialAudits} searchQuery={searchTerm} statusFilter={selectedFilters} />;
 }

--- a/src/components/audits/ActiveAuditClient.tsx
+++ b/src/components/audits/ActiveAuditClient.tsx
@@ -4,7 +4,7 @@ import React, { useState, createContext, useContext } from "react";
 import SearchAndFilter from "@/components/ui/SearchAndFilter";
 import { AuditsClient } from "@/components/audits/AuditsClient";
 import { type AuditCard } from "@/actions/activities";
-import { CirclePauseIcon , CirclePlayIcon } from "lucide-react";
+import { CirclePause , CirclePlay } from "lucide-react";
 
 // Context for search state
 const SearchContext = createContext<{
@@ -16,7 +16,7 @@ const SearchContext = createContext<{
 
 export function SearchProvider({ children }: { children: React.ReactNode }) {
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedFilters, setSelectedFilters] = useState<string[]>(["active", "queued"]);
+  const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   return (
     <SearchContext.Provider value={{ searchTerm, setSearchTerm, selectedFilters, setSelectedFilters }}>
       {children}
@@ -31,12 +31,12 @@ export function SearchInput() {
     {
       value: "active",
       label: "",
-      icon: <CirclePlayIcon className="w-4 h-4 text-primary" />
+      icon: <CirclePlay className="w-4 h-4 text-primary" />
     },
     {
       value: "queued",
       label: "",
-      icon: <CirclePauseIcon className="w-4 h-4 text-destructive" />
+      icon: <CirclePause className="w-4 h-4 text-destructive" />
     }
   ];
   return (

--- a/src/components/audits/AuditsClient.tsx
+++ b/src/components/audits/AuditsClient.tsx
@@ -4,12 +4,21 @@ import { useState } from "react";
 import { AuditStatusCard, ActiveAuditCount } from "@/components/audits";
 import { type AuditCard } from "@/actions/activities";
 
+
 interface AuditsClientProps {
   initialAudits: AuditCard[];
+  searchQuery?: string;
 }
 
-export default function AuditsClient({ initialAudits }: AuditsClientProps) {
+
+export default function AuditsClient({ initialAudits, searchQuery = "" }: AuditsClientProps) {
   const [auditCards, setAuditCards] = useState<AuditCard[]>(initialAudits);
+
+  // Filter audits by search query before rendering
+  const normalizedSearch = searchQuery.toLowerCase();
+  const filteredAudits = normalizedSearch
+    ? auditCards.filter(card => card.title.toLowerCase().includes(normalizedSearch))
+    : auditCards;
 
   const handleStatusChange = (id: string, newStatus: "active" | "queued") => {
     setAuditCards(prev => prev.map(card => 
@@ -26,8 +35,8 @@ export default function AuditsClient({ initialAudits }: AuditsClientProps) {
     setAuditCards(prev => prev.filter(card => card.id !== id));
   };
 
-  const activeAudits = auditCards.filter(card => card.statusType === "active");
-  const queuedAudits = auditCards.filter(card => card.statusType === "queued");
+  const activeAudits = filteredAudits.filter(card => card.statusType === "active");
+  const queuedAudits = filteredAudits.filter(card => card.statusType === "queued");
 
   return (
     <>

--- a/src/components/audits/AuditsClient.tsx
+++ b/src/components/audits/AuditsClient.tsx
@@ -1,24 +1,26 @@
+
 "use client";
 
 import { useState } from "react";
 import { AuditStatusCard, ActiveAuditCount } from "@/components/audits";
 import { type AuditCard } from "@/actions/activities";
 
-
 interface AuditsClientProps {
   initialAudits: AuditCard[];
   searchQuery?: string;
+  statusFilter?: string[];
 }
 
-
-export default function AuditsClient({ initialAudits, searchQuery = "" }: AuditsClientProps) {
+export function AuditsClient({ initialAudits, searchQuery = "", statusFilter = ["active", "queued"] }: AuditsClientProps) {
   const [auditCards, setAuditCards] = useState<AuditCard[]>(initialAudits);
 
-  // Filter audits by search query before rendering
+  // Filter audits by search query and status before rendering
   const normalizedSearch = searchQuery.toLowerCase();
-  const filteredAudits = normalizedSearch
-    ? auditCards.filter(card => card.title.toLowerCase().includes(normalizedSearch))
-    : auditCards;
+  const filteredAudits = auditCards.filter(card => {
+    const matchesSearch = normalizedSearch ? card.title.toLowerCase().includes(normalizedSearch) : true;
+    const matchesStatus = statusFilter.length > 0 ? statusFilter.includes(card.statusType) : true;
+    return matchesSearch && matchesStatus;
+  });
 
   const handleStatusChange = (id: string, newStatus: "active" | "queued") => {
     setAuditCards(prev => prev.map(card => 

--- a/src/components/audits/index.ts
+++ b/src/components/audits/index.ts
@@ -1,3 +1,3 @@
 export { default as AuditStatusCard } from './AuditStatusCard';
 export { default as ActiveAuditCount } from './ActiveAuditCount';
-export { default as AuditsClient } from './AuditsClient';
+export { AuditsClient } from './AuditsClient';

--- a/src/components/pages/AuditsPage.tsx
+++ b/src/components/pages/AuditsPage.tsx
@@ -1,21 +1,22 @@
+
 import Header from "@/components/common/Header";
-import SearchAndFilter from "@/components/ui/SearchAndFilter";
-import AuditsClient from "@/components/audits/AuditsClient";
 import { getActiveAudits, type AuditCard } from "@/actions/activities";
+import { SearchProvider, SearchInput, SearchableActiveAuditList } from "@/components/audits/ActiveAuditClient";
 
 export default async function AuditsPage() {
   const initialAudits: AuditCard[] = await getActiveAudits();
-
   return (
-    <main className="flex-1 p-8">
-      <Header 
-        title="Audits"
-        subtitle="Monitor real-time security analysis and threat detection"
-      >
-        <SearchAndFilter searchPlaceholder="Search audits..." />
-      </Header>
+    <SearchProvider>
+      <main className="flex-1 p-8">
+        <Header 
+          title="Audits"
+          subtitle="Monitor real-time security analysis and threat detection"
+        >
+          <SearchInput />
+        </Header>
 
-      <AuditsClient initialAudits={initialAudits} />
-    </main>
+        <SearchableActiveAuditList initialAudits={initialAudits} />
+      </main>
+    </SearchProvider>
   );
 }

--- a/src/components/pages/ProjectsPage.tsx
+++ b/src/components/pages/ProjectsPage.tsx
@@ -1,21 +1,21 @@
 import Header from "@/components/common/Header";
-import SearchAndFilter from "@/components/ui/SearchAndFilter";
 import { getProjects } from "@/actions/projects";
-import ProjectsClient from "@/components/project/ProjectsClient";
+import { SearchProvider, SearchInput, SearchableProjectsList } from "@/components/project/ProjectSearchClient";
 
 export default async function ProjectsPage(){
     const projectsData = await getProjects();
 
     return (
-        <main className="flex-1 p-8">
-            <Header 
-                title="Projects"
-                subtitle="Organize and manage your security audit projects"
-            >
-                <SearchAndFilter searchPlaceholder="Search projects..." />
-            </Header>
-            
-            <ProjectsClient projects={projectsData} />
-        </main>
+        <SearchProvider>
+            <main className="flex-1 p-8">
+                <Header 
+                    title="Projects"
+                    subtitle="Organize and manage your security audit projects"
+                >
+                    <SearchInput />
+                </Header>
+                <SearchableProjectsList projects={projectsData} />
+            </main>
+        </SearchProvider>
     );
 }

--- a/src/components/project/ProjectSearchClient.tsx
+++ b/src/components/project/ProjectSearchClient.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React, { useState, createContext, useContext } from "react";
+import SearchAndFilter from "@/components/ui/SearchAndFilter";
+import ProjectsClient from "@/components/project/ProjectsClient";
+
+interface Project {
+  id: string;
+  name: string;
+  description: string | null;
+  fileCount: number;
+  createdAt: string | Date;
+  auditCount: number;
+  _count: { audits: number };
+}
+
+const SearchContext = createContext<{
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+} | undefined>(undefined);
+
+export function SearchProvider({ children }: { children: React.ReactNode }) {
+  const [searchTerm, setSearchTerm] = useState("");
+  return (
+    <SearchContext.Provider value={{ searchTerm, setSearchTerm }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+export function SearchInput() {
+  const ctx = useContext(SearchContext);
+  if (!ctx) return null;
+  return (
+    <SearchAndFilter
+      searchPlaceholder="Search projects..."
+      onSearch={ctx.setSearchTerm}
+      showFilter={true}
+      filterOptions={[]}
+    />
+  );
+}
+
+export function SearchableProjectsList({ projects }: { projects: Project[] }) {
+  const ctx = useContext(SearchContext);
+  const searchTerm = ctx?.searchTerm?.toLowerCase() || "";
+  const filtered = searchTerm
+    ? projects.filter(project => project.name.toLowerCase().includes(searchTerm))
+    : projects;
+  return <ProjectsClient projects={filtered} />;
+}


### PR DESCRIPTION


**Description:**  
This commit adds real-time search capability to the Projects page:

- Introduces a client-side `SearchProvider` context in `ProjectsPage` to manage the search term state.
- Adds a `SearchInput` component to the header, allowing users to search projects by name.
- Refactors the projects list rendering to use a new `SearchableProjectsList` component, which filters projects based on the current search term.
- The filter button is present in the search bar for UI consistency, but no filter logic is implemented yet.
- All search logic is handled client-side, while the main page remains a server component for optimal performance.

These changes improve project discoverability and set the foundation for future filter enhancements.