### PR TITLE
feat: Clickable KPI Cards on Past Audits: Toggle Completed/Failed Filters with Active Styling

### DIFF
--- a/src/components/pastAudits/AuditStatsSection.tsx
+++ b/src/components/pastAudits/AuditStatsSection.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import KPIGrid from '@/components/common/KPIGrid';
 import { useAuditStats } from '@/hooks/useAuditStats';
+import { useContext } from 'react';
+import { SearchFilterContext } from './PastAuditsClient';
+import StatsCard from '@/components/ui/StatsCard';
+import { BarChart3, Hourglass, CheckCircle, ShieldAlert, CircleX } from 'lucide-react';
 
 export default function AuditStatsSection() {
   const { kpiData, loading, error } = useAuditStats();
+  const ctx = useContext(SearchFilterContext);
 
   if (loading) {
     return (
@@ -22,5 +26,45 @@ export default function AuditStatsSection() {
     );
   }
 
-  return <KPIGrid kpiData={kpiData} />;
+  const handleCardClick = (label: string) => {
+    if (!ctx) return;
+    if (label === 'Completed') ctx.toggleFilter('completed');
+    if (label === 'Failed') ctx.toggleFilter('failed');
+  };
+
+  // Local render to keep KPIGrid unchanged globally while enabling per-card click here
+  const iconMap: Record<string, any> = {
+    BarChart3,
+    Hourglass,
+    CheckCircle,
+    ShieldAlert,
+    CircleX
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+      {kpiData.map((k, i) => {
+        const Icon = iconMap[k.icon] || BarChart3;
+        const isToggle = k.label === 'Completed' || k.label === 'Failed';
+        const filterValue = k.label === 'Completed' ? 'completed' : k.label === 'Failed' ? 'failed' : null;
+        const isActive = filterValue ? ctx?.selectedFilters.includes(filterValue) : false;
+        return (
+          <div
+            key={i}
+            onClick={isToggle ? () => handleCardClick(k.label) : undefined}
+            className={(isToggle ? 'cursor-pointer ' : '') + ' rounded-lg'}
+          >
+            <StatsCard
+              icon={Icon}
+              label={k.label}
+              value={k.value}
+              iconColor={k.iconColor}
+              active={isActive}
+              activeClassName={k.label === 'Failed' ? 'bg-destructive/10 border border-destructive/30' : undefined}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
 }

--- a/src/components/pastAudits/PastAuditsClient.tsx
+++ b/src/components/pastAudits/PastAuditsClient.tsx
@@ -6,29 +6,38 @@ import SearchAndFilter from '@/components/ui/SearchAndFilter';
 import AuditTable from './pastAuditsTable';
 
 // Create a context for search and filter state
-const SearchFilterContext = createContext<{
+export const SearchFilterContext = createContext<{
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   selectedFilters: string[];
   setSelectedFilters: (filters: string[]) => void;
+  toggleFilter: (value: string) => void;
 }>({
   searchTerm: '',
   setSearchTerm: () => {},
   selectedFilters: [],
-  setSelectedFilters: () => {}
+  setSelectedFilters: () => {},
+  toggleFilter: () => {}
 });
 
 // Search and filter provider component
 export function SearchProvider({ children }: { children: React.ReactNode }) {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
-  
+
+  const toggleFilter = (value: string) => {
+    setSelectedFilters(prev =>
+      prev.includes(value) ? prev.filter(v => v !== value) : [...prev, value]
+    );
+  };
+
   return (
     <SearchFilterContext.Provider value={{ 
       searchTerm, 
       setSearchTerm, 
       selectedFilters, 
-      setSelectedFilters 
+      setSelectedFilters,
+      toggleFilter
     }}>
       {children}
     </SearchFilterContext.Provider>

--- a/src/components/ui/StatsCard.tsx
+++ b/src/components/ui/StatsCard.tsx
@@ -6,6 +6,9 @@ interface StatsCardProps {
   value: string | number;
   iconColor?: string;
   link?: string;
+  containerClassName?: string; // override base styling if needed
+  active?: boolean; // optional active state
+  activeClassName?: string; // override active styling
 }
 
 export default function StatsCard({
@@ -13,10 +16,14 @@ export default function StatsCard({
   label,
   value,
   iconColor = "text-primary",
-  link
+  link,
+  containerClassName = "bg-card",
+  active = false,
+  activeClassName = "bg-primary/10 border border-primary/30"
 }: StatsCardProps) {
+  const combinedClass = `${containerClassName} ${active ? activeClassName : ''}`.trim();
   const cardContent = (
-    <div className="bg-card p-6 rounded-lg shadow-sm transition-transform duration-150 hover:scale-105 hover:shadow-md cursor-pointer">
+    <div className={`${combinedClass} p-6 rounded-lg shadow-sm transition-transform duration-150 hover:scale-105 hover:shadow-md cursor-pointer`}>        
       <div className="flex items-center gap-3">
         <div className="p-2 rounded-lg">
           <Icon className={`w-6 h-6 ${iconColor}`} />


### PR DESCRIPTION



## Overview
This PR enhances the Past Audits page by making the “Completed” and “Failed” KPI statistic cards interactive. Clicking these cards now toggles their respective status filters in the audits table. The change is fully scoped to the Past Audits view; shared components (`KPIGrid`, other StatsCard usages) remain unaffected.

## Key Features
- Click-to-toggle filtering for Completed and Failed audit statuses.
- Visual active state (primary highlight for Completed, destructive tint for Failed).
- Non-interactive KPI cards (Total Audits, Total Findings) remain static.
- Preserves existing search + filter bar functionality—cards complement, not replace, the controls.

## Implementation Details
### Context Enhancements
- `SearchFilterContext` (exported from `PastAuditsClient`) now includes a `toggleFilter` function to add/remove a filter value idempotently.

### UI Changes
- Replaced the generic `KPIGrid` usage inside `AuditStatsSection` with a local grid render to keep global component behavior unchanged.
- Added local click handling logic that maps KPI labels to filter keys (`completed`, `failed`).
- Active state detection derives directly from `selectedFilters`.

### `StatsCard` Improvements
- Added optional props: `active`, `activeClassName`, and `containerClassName`.
- Defaults preserve original appearance; other consumers need no changes.
- Applies a subtle primary highlight when active; Failed cards get a destructive variant (`bg-destructive/10` + border).

## Files Modified
- `src/components/pastAudits/AuditStatsSection.tsx`
  - Added interactive rendering logic, icon mapping, active styling, and filter toggling hookups.
- `src/components/pastAudits/PastAuditsClient.tsx`
  - Exported context and introduced `toggleFilter`.
- `src/components/ui/StatsCard.tsx`
  - Introduced active-related props and conditional styling logic.

## UX Behavior
| Action | Result |
|--------|--------|
| Click “Completed” card (inactive) | Table filters to completed audits; card highlights |
| Click “Completed” card again | Completed filter removed; highlight cleared |
| Click “Failed” card | Table filters to failed audits; destructive highlight shown |
| Click “Failed” again | Failed filter removed; highlight cleared |
| Use existing filter controls | Cards reflect current selection state |

## Testing Steps
1. Navigate to Past Audits page.
2. Observe KPI cards load with counts.
3. Click “Completed” – table rows reduce to completed audits; card gains highlight.
4. Click again – highlight and filter are removed.
5. Repeat for “Failed” – destructive tint appears when active.
6. Combine both toggles – both filters applied; table shows audits matching either (confirm expected filter logic).
7. Verify other pages using `StatsCard` are unchanged.

## Accessibility & Safety
- Click targets remain large and semantically simple (div wrappers with `onClick`); could be upgraded to `button` elements later for improved semantics.
- No breaking changes to shared components; prop additions are optional.

## Follow-Up (Optional)
- Convert clickable wrappers to `<button>` for improved accessibility.
- Add keyboard toggle support (Enter/Space).
- Animate active state transitions