### PR TITLE
feat: add project edit modal with updateProject action and path revalidation

### DIFF
--- a/src/components/project/EditProjectModal.tsx
+++ b/src/components/project/EditProjectModal.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React, { useRef, useEffect, useState } from "react";
+import Button from "@/components/ui/Button";
+import { updateProject } from "@/actions/projects";
+
+interface EditProjectModalProps {
+  open: boolean;
+  onClose: () => void;
+  project: { id: string; name: string; description: string | null } | null;
+}
+
+export default function EditProjectModal({ open, onClose, project }: EditProjectModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (project) {
+      setName(project.name);
+      setDescription(project.description || "");
+    }
+  }, [project]);
+
+  if (!open || !project) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === modalRef.current) {
+      onClose();
+    }
+  };
+
+  const handleFormSubmit = () => {
+    setTimeout(() => {
+      onClose();
+    }, 100);
+  };
+
+  return (
+    <div
+      ref={modalRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-secondary/80"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-background rounded-lg shadow-lg p-8 w-full max-w-md" onClick={e => e.stopPropagation()}>
+        <h2 className="text-xl font-bold mb-4">Edit Project</h2>
+        <form className="space-y-4" action={updateProject} onSubmit={handleFormSubmit}>
+          <input type="hidden" name="id" value={project.id} />
+          <div>
+            <label className="block text-sm font-medium mb-1">Project Name</label>
+            <input
+              type="text"
+              name="name"
+              className="w-full border border-border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              placeholder="Enter project name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Description</label>
+            <textarea
+              name="description"
+              className="w-full border border-border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              placeholder="Enter project description (optional)"
+              rows={3}
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2 mt-6">
+            <Button variant="secondary" size="md" onClick={onClose} type="button">
+              Cancel
+            </Button>
+            <Button variant="primary" size="md" type="submit">
+              Save Changes
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/project/ProjectsClient.tsx
+++ b/src/components/project/ProjectsClient.tsx
@@ -4,6 +4,7 @@ import Button from "@/components/ui/Button";
 import { Plus } from "lucide-react";
 import { ProjectCard } from "@/components/project";
 import CreateProjectModal from "@/components/project/CreateProjectModal";
+import EditProjectModal from "@/components/project/EditProjectModal";
 import { useState } from "react";
 
 interface Project {
@@ -22,6 +23,8 @@ interface ProjectsClientProps {
 
 export default function ProjectsClient({ projects }: ProjectsClientProps) {
   const [modalOpen, setModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [projectBeingEdited, setProjectBeingEdited] = useState<Project | null>(null);
 
   const formatDate = (date: string | Date) => {
     const d = date instanceof Date ? date : new Date(date);
@@ -44,7 +47,9 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
   };
 
   const handleEditProject = (id: string) => {
-    console.log(`Edit project ${id}`);
+    const proj = projects.find(p => p.id === id) || null;
+    setProjectBeingEdited(proj);
+    setEditModalOpen(true);
   };
 
   const handleDeleteProject = (id: string) => {
@@ -76,6 +81,11 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
         </Button>
       </div>
       <CreateProjectModal open={modalOpen} onClose={() => setModalOpen(false)} />
+      <EditProjectModal 
+        open={editModalOpen} 
+        onClose={() => { setEditModalOpen(false); setProjectBeingEdited(null); }} 
+        project={projectBeingEdited}
+      />
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-20">
         {projects.map((project) => (
           <ProjectCard


### PR DESCRIPTION


### Summary
- Added server action `updateProject` to modify project name and description.
- Introduced `EditProjectModal` mirroring `CreateProjectModal` with pre-filled existing values.
- Integrated edit flow into `ProjectsClient`; clicking the edit icon opens the modal.
- Revalidates `/` and `/projects` after updates for fresh data.

### Implementation Details
- Validates `id` and `name`; trims input.
- Normalizes empty or whitespace-only description to `null`.
- Centralized path revalidation via an array for easy extension.
- No breaking changes to existing components.

### How to Test
1. Go to Projects page.
2. Click the edit (pencil) icon on a project card.
3. Change name and/or description; submit.
4. Modal closes; updated data appears after revalidation.
5. Clear description to confirm it’s removed (stored as `null`).

### Next Enhancements (Optional)
- Add toast notifications for success/error.
- Add `deleteProject` with confirmation.
- Optimistic UI updates.
- Switch to tag-based revalidation (`revalidateTag`) if broader caching added later.

### Changelog
Added: `EditProjectModal`, `updateProject` action  
Changed: `ProjectsClient` to wire

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Edit Project modal to update a project’s name and description with cancel/save actions.
  * Project updates now applied via form submission with automatic list refresh.
  * Past Audits: interactive KPI cards (Completed/Failed) toggle filters with accessible states.
  * Stats cards support active states and customizable styling.

* Refactor
  * Past Audits KPI display replaced with a responsive per-card grid.
  * Search filtering enhanced by exposing a toggle action through context for consistent state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->