### PR TITLE
feat: ensure unique seeded projects, align activities with existing projects, sync audit.projectName on rename

### DIFF
--- a/src/actions/projects.ts
+++ b/src/actions/projects.ts
@@ -110,6 +110,16 @@ export async function updateProject(formData: FormData) {
       data: { name, description }
     });
 
+    // Keep denormalized audit.projectName in sync so past audits reflect the new project name
+    try {
+      await prisma.audit.updateMany({
+        where: { projectId: id },
+        data: { projectName: name }
+      });
+    } catch (syncErr) {
+      console.warn('Failed to sync audit.projectName values for project', id, syncErr);
+    }
+
     // Revalidate relevant paths. Root layout to cascade, projects page specifically.
     const pathsToRevalidate = [
       '/',


### PR DESCRIPTION


### Summary
- Seed: guarantees unique project names (shuffle + slice).
- Seed: activities now only IN_PROGRESS/QUEUED and derived from existing projects (no phantom titles).
- Update action: syncs all related audits’ `projectName` when a project is renamed.

### Implementation Details
- Removed duplicate-prone random project selection; now deterministic unique set.
- Activities: 0–2 per project, last 7 days, only active queue states.
- Added `prisma.audit.updateMany` in `updateProject` with safe try/catch.

### How to Test
1. Run fresh seed: `npm run db:fresh`.
2. Confirm 6 distinct project names on Projects page.
3. Active audits page: every card title matches a project name.
4. Edit a project name; verify Past Audits reflects updated name instantly.
5. (Optional SQL) `SELECT DISTINCT "projectName" FROM audits EXCEPT SELECT name FROM projects;` returns zero rows.


### Changelog
Added: audit.projectName sync logic  
Changed: seeding for projects (unique) & activities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Projects list updates immediately after edits, ensuring changes are visible without delay.
- Bug Fixes
  - Renaming a project now keeps related audit entries in sync, preventing mismatched names.
- Chores
  - Improved demo seed data: unique project names, activities linked to projects, realistic statuses and recent timestamps, and variable activity counts per project.
  - Clearer seeding logs and conditional activity creation to avoid empty inserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->