### PR TITLE
feat(audits): add server actions for activity status updates and close with optimistic UI

### DIFF
--- a/src/actions/activities.ts
+++ b/src/actions/activities.ts
@@ -133,4 +133,60 @@ export async function getActiveAudits(): Promise<AuditCard[]> {
   }
 }
 
+// --- Mutation Server Actions ---
+// Update an activity's status (maps UI 'active'|'queued' to ActivityStatus IN_PROGRESS|QUEUED)
+export async function updateActivityStatusAction(id: string, newStatus: 'active' | 'queued'): Promise<AuditCard | null> {
+  try {
+    // Validate input
+    if (!id) throw new Error('Activity id is required')
+
+    const mappedStatus = newStatus === 'active' ? ActivityStatus.IN_PROGRESS : ActivityStatus.QUEUED
+
+    const activity = await prisma.activity.update({
+      where: { id },
+      data: {
+        status: mappedStatus,
+        // If moved back to queue, progress should typically be null again
+        progress: mappedStatus === ActivityStatus.QUEUED ? null : undefined
+      }
+    })
+
+    // Map updated record back to AuditCard shape
+    const card: AuditCard = {
+      id: activity.id,
+      title: activity.title,
+      currentStatus: activity.status === ActivityStatus.IN_PROGRESS
+        ? `scanning files (${activity.fileCount} files)`
+        : 'in queue',
+      size: activity.fileSize,
+      started: formatDateForDisplay(activity.createdAt),
+      duration: activity.status === ActivityStatus.IN_PROGRESS
+        ? calculateDuration(activity.createdAt)
+        : 'n/a',
+      progress: Math.min(100, Math.max(0, activity.progress ?? (activity.status === ActivityStatus.QUEUED ? 0 : 50))),
+      statusMessage: activity.status === ActivityStatus.IN_PROGRESS
+        ? 'Analyzing security vulnerabilities and threat patterns...'
+        : 'Queued for analysis...',
+      statusType: activity.status === ActivityStatus.IN_PROGRESS ? 'active' : 'queued'
+    }
+    return card
+  } catch (error) {
+    console.error('Error updating activity status:', error)
+    return null
+  }
+}
+
+// Close an activity (remove it from active/queued list). We delete the record.
+// Alternatively we could mark it FAILED/CANCELLED, but enum lacks CANCELLED so deletion is simplest.
+export async function closeActivityAction(id: string): Promise<{ id: string; deleted: boolean }> {
+  try {
+    if (!id) throw new Error('Activity id is required')
+    await prisma.activity.delete({ where: { id } })
+    return { id, deleted: true }
+  } catch (error) {
+    console.error('Error closing activity:', error)
+    return { id, deleted: false }
+  }
+}
+
 

--- a/src/components/pastAudits/AuditStatsSection.tsx
+++ b/src/components/pastAudits/AuditStatsSection.tsx
@@ -4,7 +4,7 @@ import { useAuditStats } from '@/hooks/useAuditStats';
 import { useContext } from 'react';
 import { SearchFilterContext } from './PastAuditsClient';
 import StatsCard from '@/components/ui/StatsCard';
-import { BarChart3, Hourglass, CheckCircle, ShieldAlert, CircleX } from 'lucide-react';
+import { BarChart3, Hourglass, CheckCircle, ShieldAlert, CircleX, type LucideIcon } from 'lucide-react';
 
 export default function AuditStatsSection() {
   const { kpiData, loading, error } = useAuditStats();
@@ -33,7 +33,8 @@ export default function AuditStatsSection() {
   };
 
   // Local render to keep KPIGrid unchanged globally while enabling per-card click here
-  const iconMap: Record<string, any> = {
+  // Map string identifiers from kpiData to icon components
+  const iconMap: Record<string, LucideIcon> = {
     BarChart3,
     Hourglass,
     CheckCircle,


### PR DESCRIPTION
Summary
-------
Add server-side actions to persist activity status changes and activity close operations, and wire them into the audits UI with optimistic updates and rollback on failure.

What changed
------------
- Added server mutation actions:
  - `updateActivityStatusAction(id, newStatus)` — updates `activity.status` (maps UI 'active'|'queued' to `IN_PROGRESS`|`QUEUED`) and returns an `AuditCard`-shaped record.
  - `closeActivityAction(id)` — deletes the activity record (used for closing an active/queued audit).
  - Location: `src/actions/activities.ts`

- Wired server actions into the client:
  - `AuditsClient` now calls the above server actions with optimistic UI updates and rollbacks on failure.
  - Location: `src/components/audits/AuditsClient.tsx`

- Small type/lint fixes surfaced by the build:
  - Typed icon mapping in `src/components/pastAudits/AuditStatsSection.tsx` to remove `any`.
  - Silence unused var warning in `AuditsClient` (internal change).

Why
---
- Persist UI changes to the database so activity status toggles and close actions reflect in the backend.
- Keep UI responsive via optimistic updates while ensuring consistency by reverting on server failure.

Behavior details
----------------
- Status toggle flow:
  1. UI optimistically toggles `statusType` for the audit card.
  2. Client calls `updateActivityStatusAction`.
  3. If server returns an updated record, client syncs computed fields (progress, message, duration).
  4. If server call fails, client reverts the optimistic toggle.

- Close flow:
  1. UI removes the audit card optimistically.
  2. Client calls `closeActivityAction` to delete the activity.
  3. If delete fails, the UI restores the removed card.

Files changed (high-level)
--------------------------
- src/actions/activities.ts — add `updateActivityStatusAction`, `closeActivityAction`
- src/components/audits/AuditsClient.tsx — call server actions + optimistic UI handling
- src/components/pastAudits/AuditStatsSection.tsx — type fixes

Testing & verification
----------------------
- Build: `npm run build` (build completed successfully in local verification)
- Manual test steps:
  1. Start dev server: `npm run dev`
  2. Navigate to Audits page.
  3. Toggle play/pause on an active audit — observe immediate UI change, then verify DB row `activities.status` updated to `IN_PROGRESS` or `QUEUED`.
  4. Click close (X) on an audit — observe immediate removal, then verify the `activities` row is deleted (or restored if operation fails).
  5. Exercise failure paths by temporarily disabling DB or injecting an error to confirm rollback behavior.

Checklist
---------
- [x] Server action to update activity status
- [x] Server action to close/delete activity
- [x] Client uses server actions with optimistic UI + rollback
- [x] Build and basic lint/type fixes applied and verified

Rollback
--------
Revert this commit/PR to restore previous behavior (UI-only toggles without persistence).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toggle an audit’s status between Active and Queued directly from the list.
  * Close audits from the UI; closed items are removed from the list.

* **Refactor**
  * Optimistic, non-blocking updates for status changes and closures provide instant feedback with automatic rollback on failure.
  * Smoother interactions through concurrency-aware updates.
  * Sensible defaults applied for audits view filters and search to streamline use.

* **Style**
  * Improved icon typing in audit stats for better type safety (no visual changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->