### PR TITLE
feat(projects): add confirmation popover for project deletion in ProjectCard

### DIFF
--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { 
   Edit, 
   Trash2, 

--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -7,7 +7,7 @@ import {
   Play
 } from "lucide-react";
 import Button from "@/components/ui/Button";
-import { useTransition, useState } from 'react';
+import { useTransition, useState, useRef, useEffect, useCallback } from 'react';
 import { deleteProjectAction } from '@/actions/projects';
 
 interface ProjectCardProps {
@@ -35,18 +35,50 @@ export default function ProjectCard({
 }: ProjectCardProps) {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const deleteBtnRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
 
-  const handleDelete = () => {
+  const handleDocumentClick = useCallback((e: MouseEvent) => {
+    if (!showConfirm) return;
+    const target = e.target as Node;
+    if (popoverRef.current && popoverRef.current.contains(target)) return;
+    if (deleteBtnRef.current && deleteBtnRef.current.contains(target)) return;
+    setShowConfirm(false);
+  }, [showConfirm]);
+
+  useEffect(() => {
+    if (showConfirm) {
+      document.addEventListener('mousedown', handleDocumentClick);
+    } else {
+      document.removeEventListener('mousedown', handleDocumentClick);
+    }
+    return () => document.removeEventListener('mousedown', handleDocumentClick);
+  }, [showConfirm, handleDocumentClick]);
+
+  const beginDelete = () => {
+    if (isPending) return;
+    setShowConfirm(true);
+  };
+
+  const confirmDelete = () => {
     setError(null);
     startTransition(async () => {
       const res = await deleteProjectAction(id);
       if (!res.deleted) {
         setError(res.error || 'Failed to delete');
+        setShowConfirm(false);
         return;
       }
-      // Notify parent so it can remove from list optimistically
       onDelete?.(id);
+      // No need to hide confirm since card will likely unmount; fallback hide
+      setShowConfirm(false);
     });
+  };
+
+  const cancelDelete = () => {
+    if (isPending) return; 
+    setShowConfirm(false);
   };
   return (
     <div className="bg-secondary rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow max-w-sm relative">
@@ -66,14 +98,50 @@ export default function ProjectCard({
           >
             <Edit className="w-4 h-4" />
           </button>
-          <button
-            onClick={handleDelete}
-            className="text-muted-foreground hover:text-destructive transition-colors disabled:opacity-50"
-            title={isPending ? 'Deleting...' : 'Delete project'}
-            disabled={isPending}
-          >
-            <Trash2 className={`w-4 h-4 ${isPending ? 'animate-pulse' : ''}`} />
-          </button>
+          <div className="relative inline-block">
+            <button
+              ref={deleteBtnRef}
+              onClick={beginDelete}
+              className="text-muted-foreground hover:text-destructive transition-colors disabled:opacity-50"
+              title={isPending ? 'Deleting...' : 'Delete project'}
+              disabled={isPending}
+              aria-haspopup="dialog"
+              aria-expanded={showConfirm}
+              aria-controls={showConfirm ? `project-delete-popover-${id}` : undefined}
+            >
+              <Trash2 className={`w-4 h-4 ${isPending ? 'animate-pulse' : ''}`} />
+            </button>
+            {showConfirm && (
+              <div
+                ref={popoverRef}
+                id={`project-delete-popover-${id}`}
+                role="dialog"
+                aria-modal="false"
+                className="absolute right-0 mt-2 w-64 z-30 rounded-md border border-border bg-popover shadow-lg p-4 animate-in fade-in-0 zoom-in-95"
+              >
+                <p className="text-sm font-medium text-foreground mb-2">Delete this project?</p>
+                <p className="text-xs text-muted-foreground mb-3">This will remove the project and its audits. This action cannot be undone.</p>
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={cancelDelete}
+                    className="px-2 py-1 text-xs rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50"
+                    disabled={isPending}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={confirmDelete}
+                    className="px-2 py-1 text-xs rounded-md bg-destructive text-white hover:bg-destructive/90 disabled:opacity-50"
+                    disabled={isPending}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Summary
-------
Add an inline confirmation popover to ProjectCard that prompts the user before deleting a project. The popover is positioned under the delete (trash) button, supports outside-click dismissal, and calls the existing server action to perform deletion.

What changed
------------
- ProjectCard now shows a confirmation dialog when the trash button is clicked.
- Dialog behavior:
  - Appears under the delete button.
  - Can be cancelled via Cancel button or by clicking outside.
  - Confirming calls `deleteProjectAction(id)` and notifies the parent via `onDelete?.(id)` on success.
  - Shows inline error badge when deletion fails and disables controls while pending.
- Accessibility:
  - `aria-haspopup`, `aria-expanded`, `aria-controls`, and `role="dialog"` added to relevant elements.

Files touched
-------------
- src/components/project/ProjectCard.tsx — add `showConfirm` state, refs, outside-click handling, and confirmation popover wired to deletion action.

Behavior / QA
-------------
1. Click the trash icon on a project card → confirmation popover appears beneath the button.
2. Click Cancel or outside the popover → popover closes, no deletion.
3. Click Delete → button enters pending state; the server action runs.
   - On success: `onDelete` is invoked (parent should remove the card).
   - On failure: an inline error badge appears and the popover closes.
4. Confirm controls are disabled while the delete is in-flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project deletion now includes a confirmation popover with Cancel/Delete and runs in the background with a visual pending indicator.
  * Other actions are temporarily disabled during deletion; a clear error badge appears if deletion fails.
  * Project lists refresh automatically after successful deletion.
  * Improved accessibility with ARIA attributes and focus/interaction handling for the popover/dialog.

* **Style**
  * Updated project card layout to host the popover, with refined positioning and smooth transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->