### PR TITLE
feat(audits/db): merge Activity into Audit, add migration, and refactor code to use audits

### DIFF
--- a/prisma/migrations/20250902000000_merge_activity_into_audit/migration.sql
+++ b/prisma/migrations/20250902000000_merge_activity_into_audit/migration.sql
@@ -1,0 +1,66 @@
+-- Manual migration: merge Activity into Audit
+-- 1. Extend audit_status enum if needed (add QUEUED, IN_PROGRESS, FAILED if missing)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid WHERE t.typname = 'audit_status' AND e.enumlabel = 'QUEUED') THEN
+    ALTER TYPE audit_status ADD VALUE IF NOT EXISTS 'QUEUED' BEFORE 'COMPLETED';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid WHERE t.typname = 'audit_status' AND e.enumlabel = 'IN_PROGRESS') THEN
+    ALTER TYPE audit_status ADD VALUE IF NOT EXISTS 'IN_PROGRESS' BEFORE 'COMPLETED';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid WHERE t.typname = 'audit_status' AND e.enumlabel = 'FAILED') THEN
+    -- FAILED likely already existed; safeguard
+    ALTER TYPE audit_status ADD VALUE IF NOT EXISTS 'FAILED';
+  END IF;
+END$$;
+
+-- 2. Add new columns to audits if they don't exist (quote camelCase)
+ALTER TABLE "public"."audits" ADD COLUMN IF NOT EXISTS "progress" INTEGER;
+ALTER TABLE "public"."audits" ADD COLUMN IF NOT EXISTS "fileCount" INTEGER;
+
+-- If an earlier failed attempt created a lowercase filecount column, rename it
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'audits' AND column_name = 'filecount'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_name = 'audits' AND column_name = 'fileCount'
+  ) THEN
+    ALTER TABLE "public"."audits" RENAME COLUMN "filecount" TO "fileCount";
+  END IF;
+END$$;
+
+-- 3. Migrate data from activities into audits
+-- Assumption: activities.title maps to audits.projectName; attempt to match by projectName & size
+-- If an audit with matching projectName & size & status not completed exists, update it, else create a new audit row.
+-- NOTE: Complex matching may need application-level script; here we do best-effort insertion of orphan activities as new audits.
+
+INSERT INTO "public"."audits" ("id", "projectId", "projectName", "size", "status", "findingsCount", "createdAt", "updatedAt", "progress", "fileCount")
+SELECT a."id", p."id" as "projectId", a."title" as "projectName", a."fileSize" as "size",
+       (CASE a."status"
+         WHEN 'IN_PROGRESS' THEN 'IN_PROGRESS'
+         WHEN 'QUEUED' THEN 'QUEUED'
+         WHEN 'COMPLETED' THEN 'COMPLETED'
+         WHEN 'FAILED' THEN 'FAILED'
+       END)::audit_status as "status",
+       0 as "findingsCount",
+       a."createdAt", a."updatedAt", a."progress", a."fileCount"
+FROM "public"."activities" a
+LEFT JOIN "public"."projects" p ON p."name" = a."title"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "public"."audits" au WHERE au."id" = a."id"
+);
+
+-- 4. Drop activities table
+DROP TABLE IF EXISTS "public"."activities";
+
+-- 5. Drop obsolete activity_status enum if exists
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'activity_status') THEN
+    -- Can't drop enum while dependent objects exist (handled by drop table above)
+    DROP TYPE activity_status;
+  END IF;
+END$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model Audit {
   projectName    String        // Denormalized for faster queries
   size           String        // File size (e.g., "4.3MB", "2.6 GB")
   status         AuditStatus
+  progress       Int?          // Progress percentage (0-100) for active audits
+  fileCount      Int?          // Number of files (used while active)
   overallSeverity SeverityLevel?
   findingsCount  Int           @default(0)
   duration       String?       // Duration in format like "30:05" (minutes:seconds)
@@ -66,30 +68,9 @@ model Finding {
   @@map("findings")
 }
 
-model Activity {
-  id        String         @id @default(cuid())
-  title     String
-  fileCount Int            // Number of files
-  fileSize  String         // File size (e.g., "2.6 MB", "1.2 GB")
-  status    ActivityStatus
-  progress  Int?           // Progress percentage (0-100), null for queued items
-  auditId   String?        // Link to the audit record when completed
-  createdAt DateTime       @default(now())
-  updatedAt DateTime       @updatedAt
-
-  @@map("activities")
-}
-
-enum ActivityStatus {
-  IN_PROGRESS
-  QUEUED
-  COMPLETED
-  FAILED
-
-  @@map("activity_status")
-}
-
 enum AuditStatus {
+  QUEUED
+  IN_PROGRESS
   COMPLETED
   FAILED
 

--- a/src/actions/active-audits.ts
+++ b/src/actions/active-audits.ts
@@ -1,0 +1,140 @@
+"use server";
+
+import { prisma } from '@/lib/prisma';
+import { AuditStatus } from '@prisma/client';
+
+export interface ActiveAuditCard {
+  id: string;
+  title: string; // projectName
+  currentStatus: string;
+  size: string;
+  started: string;
+  duration: string;
+  progress: number;
+  statusMessage: string;
+  statusType: 'active' | 'queued';
+}
+
+// Unified recent activity (formerly ActivityData) representing audits across all statuses
+export interface ActivityData {
+  id: string;
+  title: string;
+  fileCount: number;
+  size: string;
+  status: AuditStatus;
+  progress: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function formatDateForDisplay(date: Date): string {
+  const day = date.getDate();
+  const month = date.toLocaleDateString('en-US', { month: 'long' });
+  const year = date.getFullYear();
+  const time = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true
+  });
+  const getOrdinalSuffix = (d: number) => {
+    if (d > 3 && d < 21) return 'th';
+    switch (d % 10) {
+      case 1: return 'st';
+      case 2: return 'nd';
+      case 3: return 'rd';
+      default: return 'th';
+    }
+  };
+  return `${day}${getOrdinalSuffix(day)} ${month}, ${year}; ${time}`;
+}
+
+function calculateDuration(startDate: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - startDate.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffMins = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  return diffHours > 0 ? `${diffHours}h ${diffMins}m` : `${diffMins}m`;
+}
+
+export async function getActiveAuditsCards(): Promise<ActiveAuditCard[]> {
+  try {
+    const audits = await prisma.audit.findMany({
+      where: { status: { in: [AuditStatus.IN_PROGRESS, AuditStatus.QUEUED] } },
+      orderBy: [
+        { status: 'asc' },
+        { createdAt: 'desc' }
+      ]
+    });
+    return audits.map(audit => ({
+      id: audit.id,
+      title: audit.projectName,
+      currentStatus: audit.status === AuditStatus.IN_PROGRESS ? `scanning files (${audit.fileCount ?? 0} files)` : 'in queue',
+      size: audit.size,
+      started: formatDateForDisplay(audit.createdAt),
+      duration: audit.status === AuditStatus.IN_PROGRESS ? calculateDuration(audit.createdAt) : 'n/a',
+      progress: Math.min(100, Math.max(0, audit.progress ?? 0)),
+      statusMessage: audit.status === AuditStatus.IN_PROGRESS ? 'Analyzing security vulnerabilities and threat patterns...' : 'Queued for analysis...',
+      statusType: audit.status === AuditStatus.IN_PROGRESS ? 'active' : 'queued'
+    }));
+  } catch (e) {
+    console.error('Error fetching active audits:', e);
+    return [];
+  }
+}
+
+export async function getRecentActivities(limit: number = 10): Promise<ActivityData[]> {
+  try {
+    const audits = await prisma.audit.findMany({
+      where: {
+        status: { in: [AuditStatus.IN_PROGRESS, AuditStatus.QUEUED, AuditStatus.COMPLETED, AuditStatus.FAILED] }
+      },
+      orderBy: { updatedAt: 'desc' },
+      take: limit
+    });
+    return audits.map(a => ({
+      id: a.id,
+      title: a.projectName,
+      fileCount: a.fileCount ?? 0,
+      size: a.size,
+      status: a.status,
+      progress: a.progress,
+      createdAt: a.createdAt,
+      updatedAt: a.updatedAt
+    }));
+  } catch (e) {
+    console.error('Error fetching recent audit activities:', e);
+    return [];
+  }
+}
+
+export async function updateActiveAuditStatus(id: string, newStatus: 'active' | 'queued'): Promise<ActiveAuditCard | null> {
+  try {
+    if (!id) throw new Error('Audit id required');
+    const mapped = newStatus === 'active' ? AuditStatus.IN_PROGRESS : AuditStatus.QUEUED;
+    const audit = await prisma.audit.update({ where: { id }, data: { status: mapped } });
+    return {
+      id: audit.id,
+      title: audit.projectName,
+      currentStatus: audit.status === AuditStatus.IN_PROGRESS ? `scanning files (${audit.fileCount ?? 0} files)` : 'in queue',
+      size: audit.size,
+      started: formatDateForDisplay(audit.createdAt),
+      duration: audit.status === AuditStatus.IN_PROGRESS ? calculateDuration(audit.createdAt) : 'n/a',
+      progress: Math.min(100, Math.max(0, audit.progress ?? 0)),
+      statusMessage: audit.status === AuditStatus.IN_PROGRESS ? 'Analyzing security vulnerabilities and threat patterns...' : 'Queued for analysis...',
+      statusType: audit.status === AuditStatus.IN_PROGRESS ? 'active' : 'queued'
+    };
+  } catch (e) {
+    console.error('Error updating active audit status:', e);
+    return null;
+  }
+}
+
+export async function removeActiveAudit(id: string): Promise<{ id: string; deleted: boolean }> {
+  try {
+    await prisma.audit.delete({ where: { id } });
+    return { id, deleted: true };
+  } catch (e) {
+    console.error('Error removing active audit:', e);
+    return { id, deleted: false };
+  }
+}

--- a/src/actions/audits.ts
+++ b/src/actions/audits.ts
@@ -185,19 +185,20 @@ export async function createAuditRerun(originalAuditId: string) {
       throw new Error('Original audit not found')
     }
 
-    // Create a new activity for the re-run
-    const activity = await prisma.activity.create({
+    // Create a new queued audit (active audit)
+    const newAudit = await prisma.audit.create({
       data: {
-        title: originalAudit.projectName,
-        fileCount: originalAudit.project.fileCount,
-        fileSize: originalAudit.size,
+        projectId: originalAudit.projectId,
+        projectName: originalAudit.projectName,
+        size: originalAudit.size,
         status: 'QUEUED',
         progress: null,
+        fileCount: originalAudit.project.fileCount,
       }
     })
 
     return {
-      activityId: activity.id,
+      auditId: newAudit.id,
       message: 'Audit re-run has been queued successfully'
     }
   } catch (error) {

--- a/src/actions/dashboard.ts
+++ b/src/actions/dashboard.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { prisma } from '@/lib/prisma'
-import { AuditStatus, ActivityStatus } from '@prisma/client'
+import { AuditStatus } from '@prisma/client'
 
 export interface DashboardKPI {
   icon: string
@@ -16,10 +16,10 @@ export async function getDashboardKPIs(): Promise<DashboardKPI[]> {
     // Get total project count
     const projectCount = await prisma.project.count()
 
-    // Get running audits (activities with IN_PROGRESS status)
-    const runningAudits = await prisma.activity.count({
+    // Get running audits (audits with IN_PROGRESS status)
+    const runningAudits = await prisma.audit.count({
       where: {
-        status: ActivityStatus.IN_PROGRESS
+        status: AuditStatus.IN_PROGRESS
       }
     })
 

--- a/src/components/audits/ActiveAuditClient.tsx
+++ b/src/components/audits/ActiveAuditClient.tsx
@@ -3,7 +3,7 @@
 import React, { useState, createContext, useContext } from "react";
 import SearchAndFilter from "@/components/ui/SearchAndFilter";
 import { AuditsClient } from "@/components/audits/AuditsClient";
-import { type AuditCard } from "@/actions/activities";
+import { type ActiveAuditCard as AuditCard } from "@/actions/active-audits";
 import { CirclePause , CirclePlay } from "lucide-react";
 
 // Context for search state

--- a/src/components/audits/AuditsClient.tsx
+++ b/src/components/audits/AuditsClient.tsx
@@ -3,8 +3,7 @@
 
 import { useState, useTransition } from "react";
 import { AuditStatusCard, ActiveAuditCount } from "@/components/audits";
-import { type AuditCard } from "@/actions/activities";
-import { updateActivityStatusAction, closeActivityAction } from "@/actions/activities";
+import { type ActiveAuditCard as AuditCard, updateActiveAuditStatus as updateActivityStatusAction, removeActiveAudit as closeActivityAction } from "@/actions/active-audits";
 
 interface AuditsClientProps {
   initialAudits: AuditCard[];

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import type { ActivityData } from '@/actions/activities'
-import { getRecentActivities } from '@/actions/activities'
+import type { ActivityData } from '@/actions/active-audits'
+import { getRecentActivities } from '@/actions/active-audits'
 import { formatActivityStatus, formatFileInfo } from '@/lib/activity-utils'
 
 // Helper function to get progress bar color based on status
@@ -74,7 +74,7 @@ export default function RecentActivity() {
             </div>
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">
-                {formatFileInfo(activity.fileCount, activity.fileSize)}
+                {formatFileInfo(activity.fileCount, activity.size)}
               </span>
               {activity.progress !== null && (
                 <span className="text-sm text-muted-foreground">{activity.progress}%</span>

--- a/src/components/pages/AuditsPage.tsx
+++ b/src/components/pages/AuditsPage.tsx
@@ -1,6 +1,6 @@
 
 import Header from "@/components/common/Header";
-import { getActiveAudits, type AuditCard } from "@/actions/activities";
+import { getActiveAuditsCards as getActiveAudits, type ActiveAuditCard as AuditCard } from "@/actions/active-audits";
 import { SearchProvider, SearchInput, SearchableActiveAuditList } from "@/components/audits/ActiveAuditClient";
 
 export default async function AuditsPage() {

--- a/src/lib/activity-utils.ts
+++ b/src/lib/activity-utils.ts
@@ -1,7 +1,7 @@
-import { ActivityStatus } from '@prisma/client'
+import { AuditStatus } from '@prisma/client'
 
 // Helper function to format status for display
-export function formatActivityStatus(status: ActivityStatus): string {
+export function formatActivityStatus(status: AuditStatus): string {
   switch (status) {
     case 'IN_PROGRESS':
       return 'In Progress'


### PR DESCRIPTION
Summary
-------
Merge the former Activity model into the Audit model, add a manual migration to migrate data, remove the Activity model and enum, and update code to use audits for active/queued/completed/failed states. Introduces a new server actions module for active-audit behaviour and updates components to consume it.

What changed
------------
- Database:
  - Added migration: prisma/migrations/**20250902000000_merge_activity_into_audit/migration.sql**
    - Adds Audit enum values (QUEUED, IN_PROGRESS, FAILED) if missing
    - Adds progress and fileCount columns to audits (handles legacy lowercase column)
    - Copies rows from activities -> audits (best-effort)
    - Drops activities table and old enum
  - Updated prisma/schema.prisma: removed Activity model and ActivityStatus enum; added progress/fileCount/duration to Audit

- Seed:
  - prisma/seed.ts updated to seed IN_PROGRESS/QUEUED audits instead of activities

- Server actions / API:
  - Added src/actions/active-audits.ts — unified server actions for active audits:
    - getActiveAuditsCards, getRecentActivities, updateActiveAuditStatus, removeActiveAudit
  - Removed / replaced old activities action usage

- Code / Components:
  - Replaced imports and usages of activities -> active-audits across codebase:
    - src/components/dashboard/RecentActivity.tsx
    - src/components/audits/AuditsClient.tsx
    - src/components/audits/ActiveAuditClient.tsx
    - src/components/pages/AuditsPage.tsx
    - src/actions/audits.ts (rerun logic now creates queued audits)
    - src/actions/dashboard.ts (now counts audits with IN_PROGRESS)
    - src/lib/activity-utils.ts updated to use AuditStatus
  - Deleted legacy src/actions/activities.ts

Why
---
- Keep all audit-related state in a single Audit model
- Make active/queued audits first-class (progress, fileCount, duration)
- Simplify server actions and UI to operate directly on audits
- Avoid duplication and migration-related bugs going forward

Testing / QA
------------
1. Run the migration (local dev):
   - npx prisma migrate dev --name merge_activity_into_audit
   - npx prisma generate
2. Run seed (if desired) per repo setup (e.g. run configured seed script or run prisma/seed.ts)
3. Build and run the app:
   - npm run build
   - npm run dev
4. Verify:
   - Audits page shows active (IN_PROGRESS) and queued (QUEUED) audits
   - Recent Activity shows latest audits (progress, size, fileCount)
   - Rerun audit flow creates a queued audit
   - Toggling status and closing/removing active audits updates DB rows
   - No runtime/type references to the old Activity model remain

Rollback
--------
- Revert this PR to restore previous schema and code.
- If DB migration already applied, restore DB snapshot or run migration rollback (if available) and re-seed as needed.


Files (high-level)
------------------
- prisma/migrations/.../migration.sql
- prisma/schema.prisma
- prisma/seed.ts
- src/actions/active-audits.ts (new)
- src/actions/activities.ts (deleted/removed references)
- src/actions/audits.ts (refactor rerun)
- src/actions/dashboard.ts
- src/lib/activity-utils.ts
- src/components/dashboard/RecentActivity.tsx
- src/components/audits/*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Project deletion now uses a two-step confirmation with clear error feedback; related buttons are disabled during processing.
  - Active/queued audits are surfaced with richer cards (status, progress, duration) and can be updated or removed.
  - Recent activity and rerun actions now operate on audits; reruns queue a new audit.

- Refactor
  - Consolidated “activities” into “audits” across the app for a single, consistent experience.
  - Added progress and file count tracking to audits; dashboard running count reflects audits in progress.
  - Improved resilience and sorting in audit/activity lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->