### PR TITLE
feat(past-audits): add severity filters & icons and group filter dropdown sections

### DIFF
--- a/src/components/ui/FilterDropdown.tsx
+++ b/src/components/ui/FilterDropdown.tsx
@@ -57,7 +57,8 @@ export default function FilterDropdown({
       {isOpen && (
         <div className="absolute top-full left-0 mt-1 w-17 bg-background border border-border rounded-lg shadow-lg z-50">
           <div className="py-1">
-            {options.map((option) => (
+            <p className="px-3 pb-1 pt-2 text-[10px] uppercase tracking-wide text-muted-foreground font-medium">Status</p>
+            {options.filter(o => !o.value.startsWith('sev:')).map(option => (
               <label
                 key={option.value}
                 className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-secondary cursor-pointer"
@@ -70,11 +71,32 @@ export default function FilterDropdown({
                 />
                 <div className="flex items-center gap-2">
                   {option.icon}
-                  <span className="text-foreground text-xs">{option.label}</span>
                 </div>
               </label>
             ))}
           </div>
+          {/* Severity section (only if severity options exist) */}
+          {options.some(o => o.value.startsWith('sev:')) && (
+            <div className="pt-1 border-t border-border">
+              <p className="px-3 pb-1 pt-2 text-[10px] uppercase tracking-wide text-muted-foreground font-medium">Severity</p>
+              {options.filter(o => o.value.startsWith('sev:')).map(option => (
+                <label
+                  key={option.value}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-secondary cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedValues.includes(option.value)}
+                    onChange={() => handleOptionToggle(option.value)}
+                    className="w-4 h-4 text-primary bg-background border-border rounded focus:ring-primary focus:ring-2"
+                  />
+                  <div className="flex items-center gap-2">
+                    {option.icon}
+                  </div>
+                </label>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Summary
-------
Add severity-based filtering to the Past Audits page, show severity icons in the table, and visually group Status vs Severity options in the filter dropdown.

What changed
------------
- Added severity filter state and toggles to the search/filter provider.
- Passed severity filters from the UI to the server action that queries audit history.
- Displayed severity icons next to severity text in the Severity column of the past-audits table.
- Updated FilterDropdown to render distinct "Status" and "Severity" sections and hide the Severity section when no severity options are present.
- Normalized option values for severity (prefixed with `sev:`) to distinguish them from status filters.

Key files
---------
- src/actions/audits.ts — accept and apply severity[] to the audit history where clause.
- src/components/pastAudits/PastAuditsClient.tsx — add severity filter state, toggles, and build filter options with icons.
- src/components/pastAudits/pastAuditsTable.tsx — show severity icons in the Severity column and wire severity param to getAuditHistory.
- src/components/ui/FilterDropdown.tsx — grouped filter UI (Status / Severity) and conditional rendering of Severity section.
- src/components/ui/SearchAndFilter* — (updated to send grouped options through FilterDropdown)
- 
<img width="92" height="316" alt="image" src="https://github.com/user-attachments/assets/903b1551-2096-47e9-b9c4-3e5a5271af75" />


Behavior
--------
- Filter dropdown now shows a "Status" section and, if severity options exist, a separate "Severity" section.
- Selecting severity options filters the Past Audits results by overallSeverity.
- Severity column shows an icon (Flame / AlertTriangle / ShieldHalf / Info) plus the severity label.
- No Severity heading or empty section appears if no severity options are provided.

Testing / QA
------------
1. Run dev server: `npm run dev`
2. Open Past Audits page.
3. Open filter dropdown — verify Status group shown; Severity group only appears if severity options configured.
4. Select severity values (e.g., Critical, High) — verify table fetches and shows only audits matching selected severities.
5. Confirm severity icons appear in the Severity column.
6. Verify combination filtering (status + severity) works and that clearing filters resets results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Severity filtering for past audits (UI chips, icons, and server-side filtering).
  - Manage active audits: update status (Active/Queued), remove entries, and view progress/file counts.
  - “Rerun audit” now queues a new audit.
  - Recent Activity and Audits pages now show audit-based data with updated fields.
  - Delete projects with a confirmation dialog and clear success/error feedback.

- Refactor
  - Replaced Activities with Audits across the app; added QUEUED and IN_PROGRESS statuses.

- Chores
  - Database migration and seeding updated to unify activity data into audits safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->