### PR TITLE
feat(audits): clamp recent activities, reduce payload, and restrict deletes to QUEUED; preserve severity on rerun

### DIFF
--- a/src/components/pastAudits/pastAuditsTable.tsx
+++ b/src/components/pastAudits/pastAuditsTable.tsx
@@ -105,7 +105,8 @@ export default function AuditTable({
         page: currentPage, 
         limit: 20,
         search: searchQuery,
-        status: statusFilter
+        status: statusFilter,
+        severity: severityFilter
       });
       setAuditHistory(historyData);
     } catch (error) {


### PR DESCRIPTION
Summary
-------
Improve safety and performance for active/recent audits and preserve user filters during rerun refresh.

What changed
------------
- Backend / actions
  - src/actions/active-audits.ts
    - Clamp and validate `limit` for `getRecentActivities` (safe range 1–100).
    - Add `select` projection to `getRecentActivities` to reduce payload.
    - Harden `removeActiveAudit` to only allow hard-delete when audit.status === `QUEUED`; otherwise return `{ deleted: false }` and log a warning.

- UI
  - src/components/pastAudits/pastAuditsTable.tsx
    - `handleRerun` refresh now includes `severity` (severityFilter) when requesting updated history so the user's severity selection is preserved after a rerun.

Why
---
- Prevents unbounded or non-integer reads that could overload the DB.
- Reduces network and serialization cost by selecting only needed fields.
- Avoids accidental deletion of in-progress or completed audits.
- Improves UX by retaining severity filters after rerunning an audit.

Files changed
-------------
- src/actions/active-audits.ts
- src/components/pastAudits/pastAuditsTable.tsx

Testing / QA
------------
1. Call `getRecentActivities` with various limits (e.g., -5, 0, 10, 1000) — result count should be between 1 and 100.
2. Verify `getRecentActivities` responses contain only the selected fields.
3. Attempt to delete a QUEUED audit → returns `{ deleted: true }` and removes record.
4. Attempt to delete an IN_PROGRESS / COMPLETED / FAILED audit → returns `{ deleted: false }` and audit remains.
5. On Past Audits page, apply severity filters, click Re-run on an audit → table refresh keeps the severity selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add severity filters (CRITICAL/HIGH/MEDIUM/LOW) to Past Audits with matching icons.
  - Introduce Active/Queued audits list with status updates and ability to remove queued items.
  - Add project deletion confirmation with inline error feedback; buttons disable during actions.

- Refactor
  - Consolidate Activities into Audits across the app; statuses now include Queued and In Progress with progress/file count displayed where applicable.
  - Recent Activity, Audits pages, and dashboard KPIs now reference audits.
  - Re-run now creates a new queued audit and returns its ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->