### PR TITLE
feat: Enhance AuditDetailModal with accessibility improvements and backdrop click handling

### DIFF
--- a/src/components/pastAudits/AuditDetailModal.tsx
+++ b/src/components/pastAudits/AuditDetailModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
 import type { AuditStatus, SeverityLevel } from '@prisma/client';
 
@@ -36,13 +36,35 @@ interface AuditDetailModalProps {
 }
 
 export default function AuditDetailModal({ open, onClose, audit }: AuditDetailModalProps) {
+  const backdropRef = useRef<HTMLDivElement | null>(null);
+  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
+  // Escape key handler & auto-focus close button
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
-    if (open) window.addEventListener('keydown', onKey);
+    if (open) {
+      window.addEventListener('keydown', onKey);
+      // Focus close button for accessibility
+      setTimeout(() => closeBtnRef.current?.focus(), 0);
+    }
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
+
+  // Body scroll lock while modal is open
+  useEffect(() => {
+    if (!open) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = original; };
+  }, [open]);
+
+  // Outside click close
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === backdropRef.current) {
+      onClose();
+    }
+  };
 
   if (!open || !audit) return null;
 
@@ -59,11 +81,18 @@ export default function AuditDetailModal({ open, onClose, audit }: AuditDetailMo
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start md:items-center justify-center bg-black/60 py-10">
-      <div className="bg-background w-full max-w-5xl rounded-lg shadow-lg border border-border p-6 relative animate-in fade-in zoom-in-95 flex flex-col max-h-[90vh]">
+    <div
+      ref={backdropRef}
+      onMouseDown={handleBackdropMouseDown}
+      className="fixed inset-0 z-50 flex items-start md:items-center justify-center bg-black/60 py-10"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-background w-full max-w-5xl rounded-lg shadow-lg border border-border p-6 relative animate-in fade-in zoom-in-95 flex flex-col max-h-[90vh]" role="document">
         <button
+          ref={closeBtnRef}
           onClick={onClose}
-          className="absolute top-3 right-3 p-2 rounded hover:bg-secondary text-muted-foreground"
+          className="absolute top-3 right-3 p-2 rounded hover:bg-secondary text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           aria-label="Close"
         >
           <X className="w-4 h-4" />
@@ -125,7 +154,7 @@ export default function AuditDetailModal({ open, onClose, audit }: AuditDetailMo
           ) : (
             <div className="overflow-x-auto overflow-y-auto flex-1">
               <table className="w-full text-sm">
-                <thead className="bg-secondary/50">
+                <thead className="bg-secondary/50 sticky top-0 z-10 backdrop-blur supports-[backdrop-filter]:bg-secondary/40">
                   <tr>
                     <th className="text-left px-4 py-2 font-medium">Title</th>
                     <th className="text-left px-4 py-2 font-medium">Severity</th>


### PR DESCRIPTION

## Summary
This PR improves the `AuditDetailModal` component for audit reports with several accessibility and usability enhancements:
- Adds support for closing the modal by clicking the backdrop (outside the modal content).
- Locks background page scrolling while the modal is open.
- Automatically focuses the close button for keyboard accessibility.
- Adds ARIA roles for dialog and document.
- Makes the findings table header sticky for better navigation in long lists.

## Changes
- Added `useRef` for backdrop and close button.
- Added `onMouseDown` handler to backdrop for outside click-to-close.
- Added `useEffect` to lock body scroll when modal is open.
- Focuses close button when modal opens for accessibility.
- Added `role="dialog"` and `aria-modal="true"` to modal container.
- Table header in findings section is now sticky with backdrop blur.

## How to Test
1. Open an audit detail modal from the Past Audits table.
2. Try clicking outside the modal content (on the dark backdrop): modal should close.
3. While modal is open, background page should not scroll.
4. Press Escape: modal should close.
5. When modal opens, close button should be focused.
6. If findings table is long, header row should remain visible while scrolling.

## Notes
- No changes to data fetching or business logic.
- No breaking changes to modal API.
- Improves accessibility and user experience for audit report viewing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal closes when clicking outside content.
  * Body scrolling is disabled while the modal is open.
  * Sticky table header within the modal for easier scanning.

* **Refactor**
  * Improved accessibility: dialog semantics with aria-modal, focus trapped inside the modal, and focus restored on close.
  * Maintains Escape-to-close alongside enhanced focus behavior.

* **Style**
  * Enhanced focus styling for the modal’s close control.
  * Subtle backdrop-filter effect applied to the sticky header (where supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->