### PR TITLE
feat: Enhance AuditStatusCard: Disable cancel for active audits and add tooltip for cancel restrictions

### DIFF
--- a/src/components/audits/AuditStatusCard.tsx
+++ b/src/components/audits/AuditStatusCard.tsx
@@ -68,6 +68,7 @@ export default function AuditStatusCard({
   };
 
   const confirmClose = () => {
+    if (!canCancel) return;
     setShowConfirm(false);
     onClose(id);
   };


### PR DESCRIPTION


## Description

- Updated `AuditStatusCard` to improve cancel logic for audits:
  - The cancel (delete) button is now disabled for active (in-progress) audits.
  - When hovering over a disabled cancel button, a tooltip appears: "Only queued audits can be cancelled".
  - The cancel confirmation popover automatically closes if the audit becomes non-cancelable.
  - Visual feedback (opacity, cursor) and accessibility attributes (`disabled`, `aria-disabled`) are applied for clarity.
- Improves user experience and prevents accidental cancellation of in
- 
<img width="1441" height="323" alt="image" src="https://github.com/user-attachments/assets/0833fcba-0f6b-46a8-a2e0-e329395a6504" />

- 
<img width="1443" height="334" alt="image" src="https://github.com/user-attachments/assets/10e38384-5ec5-4b76-9819-6c0cd9d6e1cd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cancelling audits unless they are queued.
  * Confirmation popover now automatically closes when cancellation becomes disallowed.
  * Cancellation action is no-op if cancelling is not permitted.

* **Style**
  * Cancel button disabled and aria-disabled when not allowed; hover/active styling only when cancellable.
  * Added explanatory title message when cancellation is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->