### PR TITLE
feat: Add QueuedAuditCount badge to AuditsClient for improved audit status visibility

### DIFF
--- a/src/components/audits/AuditsClient.tsx
+++ b/src/components/audits/AuditsClient.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
-import { AuditStatusCard, ActiveAuditCount } from "@/components/audits";
+import { AuditStatusCard, ActiveAuditCount, QueuedAuditCount } from "@/components/audits";
 import { type ActiveAuditCard as AuditCard, updateActiveAuditStatus as updateActivityStatusAction, removeActiveAudit as closeActivityAction } from "@/actions/active-audits";
 
 interface AuditsClientProps {
@@ -113,6 +113,7 @@ export function AuditsClient({ initialAudits, searchQuery = "", statusFilter = [
 
       {/* Queued Audits Section */}
   <div className="space-y-4">
+        <QueuedAuditCount count={queuedAudits.length} />
         <h2 className="text-xl font-bold text-foreground mb-4">Queued Audits</h2>
         {queuedAudits.map(card => (
           <AuditStatusCard

--- a/src/components/audits/QueuedAuditCount.tsx
+++ b/src/components/audits/QueuedAuditCount.tsx
@@ -1,0 +1,28 @@
+interface QueuedAuditCountProps {
+  count: number;
+  className?: string;
+}
+
+export default function QueuedAuditCount({ count, className = "" }: QueuedAuditCountProps) {
+  return (
+    <div className={`inline-flex items-center gap-2 px-4 py-2 mb-4 rounded-full bg-yellow-50 border border-yellow-300 ${className}`}>
+      <span className="text-sm font-medium text-yellow-800">
+        {count} Queued Scan{count !== 1 ? 's' : ''}
+      </span>
+      <svg width="20px" height="20px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" id="scan-alt" className="icon glyph" fill="currentColor" transform="rotate(90)">
+        <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+        <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
+        <g id="SVGRepo_iconCarrier">
+          <path d="M8,22H4a2,2,0,0,1-2-2V16a1,1,0,0,1,2,0v4H8a1,1,0,0,1,0,2Z"></path>
+          <path d="M20,22H16a1,1,0,0,1,0-2h4V16a1,1,0,0,1,2,0v4A2,2,0,0,1,20,22Z"></path>
+          <path d="M8,22H4a2,2,0,0,1-2-2V16a1,1,0,0,1,2,0v4H8a1,1,0,0,1,0,2Z"></path>
+          <path d="M3,9A1,1,0,0,1,2,8V4A2,2,0,0,1,4,2H8A1,1,0,0,1,8,4H4V8A1,1,0,0,1,3,9Z"></path>
+          <path d="M21,9a1,1,0,0,1-1-1V4H16a1,1,0,0,1,0-2h4a2,2,0,0,1,2,2V8A1,1,0,0,1,21,9Z"></path>
+          <path d="M12,17a1,1,0,0,1-1-1V8a1,1,0,0,1,2,0v8A1,1,0,0,1,12,17Z"></path>
+          <path d="M8,15a1,1,0,0,1-1-1V10a1,1,0,0,1,2,0v4A1,1,0,0,1,8,15Z"></path>
+          <path d="M16,15a1,1,0,0,1-1-1V10a1,1,0,0,1,2,0v4A1,1,0,0,1,16,15Z"></path>
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/audits/index.ts
+++ b/src/components/audits/index.ts
@@ -1,3 +1,4 @@
 export { default as AuditStatusCard } from './AuditStatusCard';
 export { default as ActiveAuditCount } from './ActiveAuditCount';
+export { default as QueuedAuditCount } from './QueuedAuditCount';
 export { AuditsClient } from './AuditsClient';


### PR DESCRIPTION


## Description

- Created a new `QueuedAuditCount` component to display the number of queued audits in a styled badge.
- Exported `QueuedAuditCount` from the audits components index for easy reuse.
- Updated `AuditsClient` to render the queued audit count badge above the queued audits section, providing users with a clear and immediate overview of queued scan activity.
- The badge uses distinct styling to differentiate queued audits from active audits, enhancing the UI's clarity and consistency.
- This change improves the user experience by making audit status counts more prominent and accessible.
- 
<img width="256" height="123" alt="image" src="https://github.com/user-attachments/assets/4a8fd25c-a484-4116-a580-0ea737568ef3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a visible counter showing the number of queued audits in the Queued Audits section.
  - Introduced a reusable UI component that displays the count as a styled pill with an icon and proper pluralization.
  - Counter appears before the section header for quicker at-a-glance status.
  - Component is now available for reuse across the app, enabling consistent display of queued audit counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->