### PR TITLE
feat: Enhance audit report generation and display by including file location in findings

### DIFF
--- a/src/actions/audits.ts
+++ b/src/actions/audits.ts
@@ -174,8 +174,17 @@ export async function getAuditHistory({
   }
 }
 
-// Get detailed audit report with findings
-export type AuditReportWithRelations = Prisma.AuditGetPayload<{ include: { project: true; findings: true } }>
+// Get detailed audit report with findings (including file relation for path/name)
+export type AuditReportWithRelations = Prisma.AuditGetPayload<{
+  include: {
+    project: true
+    findings: {
+      include: {
+        file: { select: { name: true; path: true } }
+      }
+    }
+  }
+}>
 
 export async function getAuditReport(auditId: string): Promise<AuditReportWithRelations> {
   try {
@@ -186,6 +195,9 @@ export async function getAuditReport(auditId: string): Promise<AuditReportWithRe
       include: {
         project: true,
         findings: {
+          include: {
+            file: { select: { name: true, path: true } }
+          },
           orderBy: [
             { severity: 'desc' }, // CRITICAL, HIGH, MEDIUM, LOW
             { createdAt: 'desc' }


### PR DESCRIPTION



## Description
This PR improves both the server and client logic for audit report generation and display:

- **Server (`src/actions/audits.ts`):**
  - The `getAuditReport` action now includes the related file’s `name` and `path` for each finding, enabling richer context in audit details and exports.

- **Client (`src/components/pastAudits/pastAuditsTable.tsx`):**
  - The audit detail modal and PDF download flow now surface the file location for each finding.
  - The PDF generator (`src/lib/pdf.ts`) renders a single “Location: {path:line}” line for each finding, wrapping long paths and using the current page’s width for proper formatting.
  - The download logic is hardened against stale responses, ensures safe filename sanitization, and robustly handles PDF bytes and cleanup.

**Why?**
- This change makes it easier to trace findings to their source files, both in the UI and exported reports.
- Improves reliability and UX for audit history and report downloads.

**How to test:**
- View a past audit and confirm the findings show file location.
- Download a report and verify the PDF includes “Location: {path:line}” for each finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Findings now display associated file path/name in the UI and PDFs.
  * PDFs include a clearer Location section (file + line), replacing line-only info.

* **Bug Fixes**
  * Prevent outdated audit history/detail responses from overwriting newer data.
  * Guard against stale download triggers; only the latest PDF request proceeds.
  * More reliable PDF downloads with readable filenames and proper cleanup.
  * Clearer error notifications for fetch and download failures.

* **Style**
  * Minor loading, pagination reset, and UI cleanup refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->