### PR TITLE
feat: add user and credit models, enforce project ownership, and implement demo user with credit balance

### DIFF
--- a/prisma/migrations/20250910102453_add_user_and_credit_models_and_project_owner/migration.sql
+++ b/prisma/migrations/20250910102453_add_user_and_credit_models_and_project_owner/migration.sql
@@ -1,0 +1,52 @@
+/*
+  Warnings:
+
+  - Made the column `createdAt` on table `files` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `updatedAt` on table `files` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."files" ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "createdAt" SET NOT NULL,
+ALTER COLUMN "updatedAt" SET NOT NULL,
+ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "public"."projects" ADD COLUMN     "ownerId" TEXT;
+
+-- CreateTable
+CREATE TABLE "public"."users" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."credits" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "balance" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "credits_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "public"."users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "credits_userId_key" ON "public"."credits"("userId");
+
+-- CreateIndex
+CREATE INDEX "projects_ownerId_idx" ON "public"."projects"("ownerId");
+
+-- AddForeignKey
+ALTER TABLE "public"."projects" ADD CONSTRAINT "projects_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "public"."users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."credits" ADD CONSTRAINT "credits_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,10 +22,40 @@ model Project {
   updatedAt   DateTime @updatedAt
 
   // Relations
+  ownerId String
+  owner   User      @relation(fields: [ownerId], references: [id], onDelete: Restrict)
   audits Audit[]
   files  File[]
 
+  @@index([ownerId])
   @@map("projects")
+}
+
+model User {
+  id        String    @id @default(cuid())
+  email     String    @unique
+  name      String?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  // Relations
+  projects Project[]
+  credit   Credit?
+
+  @@map("users")
+}
+
+model Credit {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  balance   Int      @default(0) // user's credit score/balance, default zero
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("credits")
 }
 
 model Audit {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -97,8 +97,15 @@ async function main() {
   await prisma.$executeRawUnsafe('DELETE FROM files');
   await prisma.audit.deleteMany()
   await prisma.project.deleteMany()
+  await prisma.credit.deleteMany()
+  await prisma.user.deleteMany()
   console.log('🧹 Cleared existing data')
   
+  // Ensure a demo user with a starting credit balance
+  const demoEmail = process.env.DEMO_USER_EMAIL || 'demo@oal.local'
+  const demoUser = await prisma.user.create({ data: { email: demoEmail, name: 'Demo User' } })
+  await prisma.credit.create({ data: { userId: demoUser.id, balance: 694200 } })
+
   // Create projects first (ensure unique names)
   const shuffledTypes = faker.helpers.shuffle(projectTypes)
   const selectedTypes = shuffledTypes.slice(0, 6)
@@ -106,7 +113,8 @@ async function main() {
   const projects = selectedTypes.map(name => ({
     name,
     description: faker.company.catchPhrase(),
-    fileCount: 0
+    fileCount: 0,
+    ownerId: demoUser.id,
   }))
 
   const createdProjects = await Promise.all(projects.map(project => prisma.project.create({ data: project })))

--- a/src/actions/projects.ts
+++ b/src/actions/projects.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from '@/lib/prisma'
 import { revalidatePath } from "next/cache";
+import { ensureDemoUserWithCredit } from '@/lib/user'
 
 // Get all projects
 export async function getProjects() {
@@ -72,11 +73,15 @@ export async function createProject(formData: FormData) {
     const rawFileCount = formData.get('fileCount');
     const parsed = typeof rawFileCount === 'string' ? Number(rawFileCount) : 0;
     const fileCount = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    
+  const user = await ensureDemoUserWithCredit();
+
     await prisma.project.create({
       data: {
         name,
         description,
-        fileCount
+        fileCount,
+        ownerId: user.id
       }
     });
     revalidatePath("/projects");

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import SidebarClient from "@/components/common/SidebarClient";
 import PageRouter from "@/components/common/PageRouter";
 import { TabType } from "@/components/common/PageRouter";
+import { getCurrentUserCredits } from "@/lib/user";
+
 
 interface PageProps {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -12,6 +14,7 @@ export default async function Dashboard({ searchParams }: PageProps) {
   const activeTab: TabType = tab && ["dashboard", "audits", "past-audits", "projects"].includes(tab) 
     ? tab 
     : "dashboard";
+  const creditsLeft = await getCurrentUserCredits();
 
   return (
     <div className="min-h-screen bg-background">
@@ -20,7 +23,7 @@ export default async function Dashboard({ searchParams }: PageProps) {
       
       <div className="flex">
         {/* Left Sidebar */}
-        <SidebarClient activeTab={activeTab} />
+      <SidebarClient activeTab={activeTab} creditsLeft={creditsLeft} />
 
         {/* Main Content */}
         <PageRouter activeTab={activeTab} />

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,0 +1,24 @@
+import { prisma } from '@/lib/prisma'
+
+const DEMO_EMAIL = process.env.DEMO_USER_EMAIL || 'demo@oal.local'
+
+export async function ensureDemoUserWithCredit() {
+  // Find or create demo user
+  let user = await prisma.user.findUnique({ where: { email: DEMO_EMAIL } })
+  if (!user) {
+    user = await prisma.user.create({ data: { email: DEMO_EMAIL, name: 'Demo User' } })
+  }
+  // Ensure credit row exists
+  await prisma.credit.upsert({
+    where: { userId: user.id },
+    update: {},
+    create: { userId: user.id, balance: 0 }
+  })
+  return user
+}
+
+export async function getCurrentUserCredits(): Promise<number> {
+  const user = await ensureDemoUserWithCredit()
+  const credit = await prisma.credit.findUnique({ where: { userId: user.id } })
+  return credit?.balance ?? 0
+}


### PR DESCRIPTION



## Description

This PR introduces a user and credit system to the backend and enforces project ownership:

- Adds `User` and `Credit` models to the Prisma schema, with each project now requiring an `ownerId` (referencing a user).
- Updates the seed script to create a demo user with a large starting credit balance and assigns all seeded projects to this user.
- Implements a helper (`ensureDemoUserWithCredit`) to guarantee a demo user and credit row exist, used in project creation and credit queries.
- Refactors project creation to always assign an owner and ensure the owner has a credit score.
- Updates the dashboard page to fetch and display the current user's credit balance in the sidebar.
- Ensures all new and seeded projects have a valid owner and that every user has a credit score.

These changes lay the foundation for user-based credit management and make project ownership mandatory, improving data integrity and supporting future features like credit top-up and