### PR TITLE
feat: Add ProjectDetailModal component and integrate it into ProjectsClient for displaying project details

### DIFF
--- a/src/components/project/ProjectCard.tsx
+++ b/src/components/project/ProjectCard.tsx
@@ -86,9 +86,23 @@ export default function ProjectCard({
     setShowConfirm(false);
   };
   const handleCardClick = (e: React.MouseEvent) => {
-    // Prevent clicks originating from action buttons triggering the modal
+    // 1. If confirm popover is open, ignore all card clicks
+    if (showConfirm) return;
     const target = e.target as HTMLElement;
-    if (target.closest('button')) return;
+    // 2. Ignore clicks inside the confirm popover
+    if (popoverRef.current && popoverRef.current.contains(target)) return;
+    // 3. Ignore clicks on interactive elements (buttons, links, form controls, opt-out data attr)
+    const interactiveSelector = [
+      'button',
+      'a[href]',
+      '[role="button"]',
+      'input',
+      'select',
+      'textarea',
+      '[data-ignore-card-click="true"]'
+    ].join(',');
+    if (target.closest(interactiveSelector)) return;
+    // 4. Only open details if none of the above matched
     onOpenDetails?.(id);
   };
 

--- a/src/components/project/ProjectDetailModal.tsx
+++ b/src/components/project/ProjectDetailModal.tsx
@@ -31,17 +31,35 @@ export default function ProjectDetailModal({ open, project, onClose }: ProjectDe
   }, [open, onClose]);
 
   useEffect(() => {
-    if (open && dialogRef.current) {
-      dialogRef.current.focus();
+    let previousActive: Element | null = null;
+    let previousOverflow: string = '';
+    if (open) {
+      previousActive = document.activeElement;
+      previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      if (dialogRef.current) {
+        dialogRef.current.focus();
+      }
     }
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (previousActive && document.contains(previousActive)) {
+        (previousActive as HTMLElement).focus();
+      }
+    };
   }, [open]);
 
   if (!open || !project) return null;
 
-  const createdDate = new Date(project.createdAt);
-  const formattedDate = createdDate.toLocaleDateString(undefined, {
-    year: 'numeric', month: 'long', day: 'numeric'
-  });
+  let formattedDate = '';
+  const date = new Date(project.createdAt);
+  if (!project.createdAt || Number.isNaN(date.getTime())) {
+    formattedDate = 'Unknown date';
+  } else {
+    formattedDate = date.toLocaleDateString(undefined, {
+      year: 'numeric', month: 'long', day: 'numeric'
+    });
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">

--- a/src/components/project/ProjectsClient.tsx
+++ b/src/components/project/ProjectsClient.tsx
@@ -86,7 +86,15 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
   const handleOpenDetails = (id: string) => {
     const proj = projects.find(p => p.id === id) || null;
     setDetailProject(proj);
-    setDetailOpen(true);
+    if (proj) {
+      setDetailOpen(true);
+    } else {
+      if (typeof toast === 'function') {
+        toast.error?.('Project not found');
+      } else {
+        window.alert('Project not found');
+      }
+    }
   };
 
   const handleCreateProject = () => {


### PR DESCRIPTION




## Description

This PR introduces a modal for viewing detailed information about a project and integrates it into the projects grid UI.

### Features

- **ProjectDetailModal Component**
  - New modal component that displays all key project details: name, description, file count, creation date, audit count, and project ID.
  - Modal is accessible (focus, Escape key, click outside to close).
  - Placeholder for future features: recent audits, severity distribution, credit usage.
  - 
<img width="1231" height="681" alt="image" src="https://github.com/user-attachments/assets/8635c8bc-a776-442c-b10a-dbcb688b62f9" />


- **ProjectCard Enhancements**
  - Card now supports an `onOpenDetails` prop.
  - Clicking anywhere on the card (except action buttons) opens the detail modal.

- **ProjectsClient Integration**
  - Manages modal open/close state and passes selected project data to the modal.
  - Wires up `onOpenDetails` for each card in the grid.

### Benefits

- Provides a user-friendly way to view all project information at a glance.
- Lays the foundation for future enhancements (audit history, credit usage, owner info).
- Improves UX and accessibility for project management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a project details modal showing name, description, created date, file count, audit count, and ID; includes a placeholder "Recent Audits (coming soon)".
  - Modal opens when a project card is clicked (excluding action buttons) and can be closed via backdrop click or Escape; it auto-focuses when opened.

- UX Improvements
  - Project cards are now visually clickable (pointer cursor) while preserving existing action button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->