### PR TITLE
feat: add logout confirmation modal and toast notification to sidebar

### DIFF
--- a/src/components/auth/LogoutConfirmModal.tsx
+++ b/src/components/auth/LogoutConfirmModal.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import React, { useRef } from 'react';
+import Button from '@/components/ui/Button';
+
+interface LogoutConfirmModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  pending?: boolean;
+}
+
+export default function LogoutConfirmModal({ open, onCancel, onConfirm, pending }: LogoutConfirmModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  if (!open) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === modalRef.current) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div
+      ref={modalRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-secondary/80"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-background rounded-lg shadow-lg p-8 w-full max-w-sm" onClick={e => e.stopPropagation()}>
+        <h2 className="text-lg font-bold mb-2">Confirm Logout</h2>
+        <p className="text-sm text-muted-foreground mb-6">Are you sure you want to log out? You will need to log back in to resume your session.</p>
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" size="sm" type="button" onClick={onCancel} disabled={pending}>Cancel</Button>
+          <Button variant="primary" size="sm" type="button" onClick={onConfirm} disabled={pending} className="bg-destructive hover:bg-destructive/90 text-white">
+            {pending ? 'Logging out...' : 'Log out'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION



## PR Description

### Features
- Added `LogoutConfirmModal` component (`src/components/auth/LogoutConfirmModal.tsx`) for a user-friendly logout confirmation dialog.
- Replaced native `window.confirm` with a custom modal in `SidebarClient` for improved UX and accessibility.
- Modal disables closing while logout is pending, and supports backdrop click-to-close.
- On confirmation, triggers logout server action, shows toast notification (success or error), and redirects to `/login`.

### Implementation
- Modal styled and structured to match existing project modals (see `CreateProjectModal`).
- Used Button component with destructive styling for the logout action.
- Integrated toast notifications using `sonner` for feedback.
- All type checks pass; no breaking changes.

### Files Changed
- `src/components/common/SidebarClient.tsx` (modal integration, logic update)
- `src/components/auth/LogoutConfirmModal.tsx` (new component)

### Notes
- Modal is reusable for other confirmation flows if needed.
- No breaking changes; all new logic is opt-in and isolated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing logout option in the sidebar with a two-step confirmation flow.
  * Introduced a confirmation modal with Cancel and Log out actions.
  * Shows a loading state and disables controls during logout to prevent accidental actions.
  * Provides error notifications on failure and redirects to the login page on success.
  * Sidebar footer updated to include the Log out button alongside credits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->