### PR TITLE
feat: add no projects and no active audits messages for better user feedback

### DIFF
--- a/src/components/audits/AuditsClient.tsx
+++ b/src/components/audits/AuditsClient.tsx
@@ -93,44 +93,56 @@ export function AuditsClient({ initialAudits, searchQuery = "", statusFilter = [
       {/* Active Audits Section */}
   <div className="mb-8 space-y-4">
         <h2 className="text-xl font-bold text-foreground mb-4">Active Audits</h2>
-        {activeAudits.map(card => (
-          <AuditStatusCard
-            key={card.id}
-            id={card.id}
-            title={card.title}
-            currentStatus={card.currentStatus}
-            size={card.size}
-            started={card.started}
-            duration={card.duration}
-            progress={card.progress}
-            statusMessage={card.statusMessage}
-            statusType={card.statusType}
-            onStatusChange={handleStatusChange}
-            onClose={handleClose}
-          />
-        ))}
+        {activeAudits.length === 0 ? (
+          <div className="rounded-md bg-secondary border border-dashed border-border p-4 text-sm text-muted-foreground ">
+            No active audits available.
+          </div>
+        ) : (
+          activeAudits.map(card => (
+            <AuditStatusCard
+              key={card.id}
+              id={card.id}
+              title={card.title}
+              currentStatus={card.currentStatus}
+              size={card.size}
+              started={card.started}
+              duration={card.duration}
+              progress={card.progress}
+              statusMessage={card.statusMessage}
+              statusType={card.statusType}
+              onStatusChange={handleStatusChange}
+              onClose={handleClose}
+            />
+          ))
+        )}
       </div>
 
       {/* Queued Audits Section */}
   <div className="space-y-4">
         <QueuedAuditCount count={queuedAudits.length} />
         <h2 className="text-xl font-bold text-foreground mb-4">Queued Audits</h2>
-        {queuedAudits.map(card => (
-          <AuditStatusCard
-            key={card.id}
-            id={card.id}
-            title={card.title}
-            currentStatus={card.currentStatus}
-            size={card.size}
-            started={card.started}
-            duration={card.duration}
-            progress={card.progress}
-            statusMessage={card.statusMessage}
-            statusType={card.statusType}
-            onStatusChange={handleStatusChange}
-            onClose={handleClose}
-          />
-        ))}
+        {queuedAudits.length === 0 ? (
+          <div className="rounded-md border bg-secondary border-dashed border-border p-4 text-sm text-muted-foreground">
+            No queued audits available.
+          </div>
+        ) : (
+          queuedAudits.map(card => (
+            <AuditStatusCard
+              key={card.id}
+              id={card.id}
+              title={card.title}
+              currentStatus={card.currentStatus}
+              size={card.size}
+              started={card.started}
+              duration={card.duration}
+              progress={card.progress}
+              statusMessage={card.statusMessage}
+              statusType={card.statusType}
+              onStatusChange={handleStatusChange}
+              onClose={handleClose}
+            />
+          ))
+        )}
       </div>
     </>
   );

--- a/src/components/project/ProjectsClient.tsx
+++ b/src/components/project/ProjectsClient.tsx
@@ -136,23 +136,30 @@ export default function ProjectsClient({ projects }: ProjectsClientProps) {
           auditCount: detailProject.auditCount ?? detailProject._count?.audits ?? 0,
         } : null}
       />
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-20">
-        {projects.map((project) => (
-          <ProjectCard
-            key={project.id}
-            id={project.id}
-            title={project.name}
-            description={project.description || "No description provided."}
-            fileCount={project.fileCount}
-            date={formatDate(project.createdAt)}
-            onEdit={handleEditProject}
-            onDelete={handleDeleteProject}
-            onAddFiles={handleAddFiles}
-            onRunAudit={handleRunAudit}
-            onOpenDetails={handleOpenDetails}
-          />
-        ))}
-      </div>
+      {projects.length === 0 ? (
+        <div className="rounded-md border bg-secondary border-dashed border-border p-8 text-center text-muted-foreground text-lg">
+          No projects available.<br />
+          <span className="block mt-2">Create a project to get started.</span>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-20">
+          {projects.map((project) => (
+            <ProjectCard
+              key={project.id}
+              id={project.id}
+              title={project.name}
+              description={project.description || "No description provided."}
+              fileCount={project.fileCount}
+              date={formatDate(project.createdAt)}
+              onEdit={handleEditProject}
+              onDelete={handleDeleteProject}
+              onAddFiles={handleAddFiles}
+              onRunAudit={handleRunAudit}
+              onOpenDetails={handleOpenDetails}
+            />
+          ))}
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## feat: add no projects and no active audits messages for better user feedback

This PR improves user experience by providing clear feedback when there is no data to display in key dashboard sections.

### Changes

- **Projects Page:**  
  - When there are no projects, a friendly message box is shown:  
    “No projects available. Create a project to get started.”
  - Uses a rounded, dashed border and muted color for visual clarity.
  - 
<img width="1444" height="327" alt="image" src="https://github.com/user-attachments/assets/af31168f-e848-4983-9684-c40f4e5c9a9d" />


- **Audits Page:**  
  - When there are no active audits, displays:  
    “No active audits available.”
  - When there are no queued audits, displays:  
    “No queued audits available.”
  - Both use a styled box for consistency and visibility.
  - 
<img width="1434" height="472" alt="image" src="https://github.com/user-attachments/assets/0b6ae8cf-8355-4a45-ae2c-3d06534281a0" />


These enhancements help guide users to take action and reduce confusion when lists are empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear empty-state messages for Active Audits and Queued Audits when no items are available.
  * Added an empty-state for Projects with guidance to create a project when none exist.

* **Style**
  * Introduced consistent, subtle styling for empty states using bordered, dashed placeholders and muted text to improve clarity without visual clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->